### PR TITLE
Add incremental fetching for API account statements

### DIFF
--- a/mecon/etl/account_statements.py
+++ b/mecon/etl/account_statements.py
@@ -205,8 +205,42 @@ class APIAccountStatementsSource(AccountStatementsSource, abc.ABC):
         pass
 
     @abc.abstractmethod
-    def fetch(self):
+    def fetch(self, since: dt.datetime | None = None):
+        """Fetch new statement data from the remote API.
+
+        Args:
+            since: Fetch transactions occurring after this datetime. If ``None``
+                the implementation should fetch all available data.
+        """
         pass
+
+    def fetch_if_needed_and_transform(self, *, force_fetch: bool = False) -> Transactions:
+        """Fetch missing statement data and return transformed transactions.
+
+        If ``force_fetch`` is ``True`` all data will be fetched from the API
+        regardless of what is already stored locally. Otherwise this method
+        determines the maximum transaction date from the currently available
+        files and fetches data only for the missing days.
+        """
+
+        existing_transactions = self.to_transactions()
+        _, last_date = existing_transactions.date_range()
+
+        if force_fetch:
+            self.fetch()
+            return self.to_transactions()
+
+        today = datetime.now().date()
+        if last_date is None or last_date < today:
+            since_dt = None
+            if last_date is not None:
+                since_dt = datetime.combine(
+                    last_date + dt.timedelta(days=1),
+                    datetime.min.time(),
+                ).replace(tzinfo=dt.timezone.utc)
+            self.fetch(since=since_dt)
+            return self.to_transactions()
+        return existing_transactions
 
 
 class TrueLayerStatements(APIAccountStatementsSource):
@@ -236,11 +270,14 @@ class TrueLayerStatements(APIAccountStatementsSource):
             api_handler=TrueLayerClient(creds)
         )
 
-    def fetch(self):
+    def fetch(self, since: dt.datetime | None = None):
         fetch_datetime = datetime.now().date()
         fetch_job_id = str(uuid.uuid4())
 
-        json_transactions = self.api_handler.get_transactions(self.bank.lower(), self.account_id)
+        from_date = since.date() if since else None
+        json_transactions = self.api_handler.get_transactions(
+            self.bank.lower(), self.account_id, from_date=from_date
+        )
         df = json_to_csv(json_transactions)
         if len(df) == 0:
             logging.info(
@@ -322,10 +359,11 @@ class Trading212APIStatements(APIAccountStatementsSource):
             api_handler=Trading212Client(creds)
         )
 
-    def fetch(self, since=dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)):
+    def fetch(self, since: dt.datetime | None = None):
         fetch_datetime = datetime.now().date()
         fetch_job_id = str(uuid.uuid4())
 
+        since = since or dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
         df = self.api_handler.fetch_history_dataframe(since=since)
         if len(df) == 0:
             logging.info(
@@ -351,11 +389,16 @@ class MonzoAPIStatements(APIAccountStatementsSource):
             api_handler=MonzoClient(creds)
         )
 
-    def fetch(self, since="2019-01-01T00:00:00Z"):
+    def fetch(self, since: dt.datetime | None = None):
         fetch_datetime = datetime.now().date()
         fetch_job_id = str(uuid.uuid4())
 
-        df = self.api_handler.download_full_history(since=since)
+        since_str = (
+            since.isoformat().replace("+00:00", "Z")
+            if since
+            else "2019-01-01T00:00:00Z"
+        )
+        df = self.api_handler.download_full_history(since=since_str)
         if len(df) == 0:
             logging.info(
                 f"{self.__class__.__name__}: No transactions fetched for Monzo-API since {self}. No file added to {self.dir_name}.")

--- a/mecon/etl/account_statements.py
+++ b/mecon/etl/account_statements.py
@@ -214,18 +214,20 @@ class APIAccountStatementsSource(AccountStatementsSource, abc.ABC):
         """
         pass
 
-    def fetch_if_needed_and_transform(self, *, force_fetch: bool = False) -> Transactions:
+    def fetch_if_needed_and_transform(
+            self, *, force_fetch: bool = False
+    ) -> tuple[Transactions, bool]:
         """Fetch missing statement data and return transformed transactions.
 
-        If ``force_fetch`` is ``True`` all data will be fetched from the API
-        regardless of what is already stored locally. Otherwise this method
-        determines the maximum transaction date from the currently available
-        files and fetches data only for the missing days.
+        Returns a tuple ``(transactions, fetched)`` where ``transactions`` is
+        the latest ``Transactions`` object and ``fetched`` indicates whether a
+        remote fetch was performed. If ``force_fetch`` is ``True`` all data will
+        be fetched regardless of what is already stored locally.
         """
 
         if force_fetch:
             self.fetch()
-            return self.to_transactions()
+            return self.to_transactions(), True
 
         existing_transactions = self.to_transactions()
         _, last_date = existing_transactions.date_range()
@@ -239,9 +241,8 @@ class APIAccountStatementsSource(AccountStatementsSource, abc.ABC):
                     datetime.min.time(),
                 ).replace(tzinfo=dt.timezone.utc)
             self.fetch(since=since_dt)
-            return self.to_transactions()
-        return existing_transactions
-
+            return self.to_transactions(), True
+        return existing_transactions, False
 
 class TrueLayerStatements(APIAccountStatementsSource):
     bank = None

--- a/mecon/etl/account_statements.py
+++ b/mecon/etl/account_statements.py
@@ -223,12 +223,12 @@ class APIAccountStatementsSource(AccountStatementsSource, abc.ABC):
         files and fetches data only for the missing days.
         """
 
-        existing_transactions = self.to_transactions()
-        _, last_date = existing_transactions.date_range()
-
         if force_fetch:
             self.fetch()
             return self.to_transactions()
+
+        existing_transactions = self.to_transactions()
+        _, last_date = existing_transactions.date_range()
 
         today = datetime.now().date()
         if last_date is None or last_date < today:

--- a/services/main_shiny/main_app.py
+++ b/services/main_shiny/main_app.py
@@ -366,7 +366,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         logging.info(f"Fetching {len(fsources)} sources...")
         for source in fsources:
             try:
-                source.fetch()
+                source.fetch_if_needed_and_transform()
                 logging.error(f"Successfully fetched source {source}")
                 ui.notification_show(
                     f"Successfully fetched source {source}",

--- a/services/main_shiny/main_app.py
+++ b/services/main_shiny/main_app.py
@@ -366,10 +366,14 @@ def server(input: Inputs, output: Outputs, session: Session):
         logging.info(f"Fetching {len(fsources)} sources...")
         for source in fsources:
             try:
-                source.fetch_if_needed_and_transform()
-                logging.error(f"Successfully fetched source {source}")
+                _, fetched_flag = source.fetch_if_needed_and_transform()
+                if fetched_flag:
+                    message = f"Successfully fetched source {source}"
+                else:
+                    message = f"SKIPPED fetching source {source}, was fetched recently"
+                logging.info(message)
                 ui.notification_show(
-                    f"Successfully fetched source {source}",
+                    message,
                     type='message',
                     duration=5
                 )

--- a/tests/test_account_statements.py
+++ b/tests/test_account_statements.py
@@ -1,0 +1,115 @@
+import datetime as dt
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest import mock
+
+import pandas as pd
+
+from mecon.etl.account_statements import (
+    APIAccountStatementsSource,
+    TrueLayerStatements,
+    Trading212APIStatements,
+    MonzoAPIStatements,
+)
+
+
+class DummyTrueLayer(TrueLayerStatements):
+    """Minimal TrueLayer source for testing."""
+
+    id = "DUMMYTL"
+    dir_name = "DUMMYTL"
+    bank = "ob-test"
+    account_id = "acc"
+
+    def __init__(self, working_dir: Path, api_handler):
+        super().__init__(
+            working_dir=working_dir,
+            trans_transformer=mock.MagicMock(),
+            api_handler=api_handler,
+        )
+
+
+class DummyAPIAccount(APIAccountStatementsSource):
+    """Simple source to test fetch_if_needed_and_transform."""
+
+    id = "DUMMY"
+    dir_name = "DUMMY"
+
+    @classmethod
+    def from_path_and_creds(cls, working_dir: Path, creds):
+        return cls(working_dir, mock.MagicMock(), mock.MagicMock())
+
+    def fetch(self, since: dt.datetime | None = None):  # pragma: no cover - mocked
+        pass
+
+
+class FetchImplementationTests(unittest.TestCase):
+    def test_truelayer_fetch_passes_from_date(self):
+        api_handler = mock.MagicMock()
+        with TemporaryDirectory() as tmpdir:
+            source = DummyTrueLayer(Path(tmpdir), api_handler)
+            since = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+            with mock.patch(
+                "mecon.etl.account_statements.json_to_csv", return_value=pd.DataFrame()
+            ):
+                source.fetch(since=since)
+        api_handler.get_transactions.assert_called_once_with(
+            "ob-test", "acc", from_date=since.date()
+        )
+
+    def test_trading212_fetch_passes_since_datetime(self):
+        api_handler = mock.MagicMock(return_value=pd.DataFrame())
+        with TemporaryDirectory() as tmpdir:
+            source = Trading212APIStatements(
+                working_dir=Path(tmpdir),
+                trans_transformer=mock.MagicMock(),
+                api_handler=api_handler,
+            )
+            since = dt.datetime(2021, 5, 4, tzinfo=dt.timezone.utc)
+            source.fetch(since=since)
+        api_handler.fetch_history_dataframe.assert_called_once_with(since=since)
+
+    def test_monzo_fetch_passes_since_string(self):
+        api_handler = mock.MagicMock(return_value=pd.DataFrame())
+        with TemporaryDirectory() as tmpdir:
+            source = MonzoAPIStatements(
+                working_dir=Path(tmpdir),
+                trans_transformer=mock.MagicMock(),
+                api_handler=api_handler,
+            )
+            since = dt.datetime(2022, 2, 3, tzinfo=dt.timezone.utc)
+            source.fetch(since=since)
+        api_handler.download_full_history.assert_called_once_with(
+            since="2022-02-03T00:00:00Z"
+        )
+
+
+class FetchIfNeededTests(unittest.TestCase):
+    def test_fetch_if_needed_and_transform_fetches_missing_days(self):
+        with TemporaryDirectory() as tmpdir:
+            source = DummyAPIAccount(
+                working_dir=Path(tmpdir),
+                trans_transformer=mock.MagicMock(),
+                api_handler=mock.MagicMock(),
+            )
+            last_date = dt.date.today() - dt.timedelta(days=2)
+            existing = mock.Mock()
+            existing.date_range.return_value = (None, last_date)
+            final = mock.Mock()
+            source.to_transactions = mock.MagicMock(side_effect=[existing, final])
+            source.fetch = mock.MagicMock()
+
+            result = source.fetch_if_needed_and_transform()
+
+        expected_since = dt.datetime.combine(
+            last_date + dt.timedelta(days=1),
+            dt.datetime.min.time(),
+        ).replace(tzinfo=dt.timezone.utc)
+        source.fetch.assert_called_once_with(since=expected_since)
+        self.assertEqual(result, final)
+        self.assertEqual(source.to_transactions.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_account_statements.py
+++ b/tests/test_account_statements.py
@@ -100,7 +100,7 @@ class FetchIfNeededTests(unittest.TestCase):
             source.to_transactions = mock.MagicMock(side_effect=[existing, final])
             source.fetch = mock.MagicMock()
 
-            result = source.fetch_if_needed_and_transform()
+            result, fetched = source.fetch_if_needed_and_transform()
 
         expected_since = dt.datetime.combine(
             last_date + dt.timedelta(days=1),
@@ -108,7 +108,28 @@ class FetchIfNeededTests(unittest.TestCase):
         ).replace(tzinfo=dt.timezone.utc)
         source.fetch.assert_called_once_with(since=expected_since)
         self.assertEqual(result, final)
+        self.assertTrue(fetched)
         self.assertEqual(source.to_transactions.call_count, 2)
+
+    def test_fetch_if_needed_and_transform_skips_when_up_to_date(self):
+        with TemporaryDirectory() as tmpdir:
+            source = DummyAPIAccount(
+                working_dir=Path(tmpdir),
+                trans_transformer=mock.MagicMock(),
+                api_handler=mock.MagicMock(),
+            )
+            last_date = dt.date.today()
+            existing = mock.Mock()
+            existing.date_range.return_value = (None, last_date)
+            source.to_transactions = mock.MagicMock(return_value=existing)
+            source.fetch = mock.MagicMock()
+
+            result, fetched = source.fetch_if_needed_and_transform()
+
+        source.fetch.assert_not_called()
+        self.assertFalse(fetched)
+        self.assertEqual(result, existing)
+        source.to_transactions.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add generic since parameter to API account statement fetch methods
- implement fetch_if_needed_and_transform to fetch only missing days
- standardize API-specific fetch implementations

## Testing
- `pytest` *(fails: No module named 'httpx'; missing test dataset)*

------
https://chatgpt.com/codex/tasks/task_e_68b7782a89d88326a5c2d12e858cbf13