### PR TITLE
Ensure Monzo client persists refreshed tokens

### DIFF
--- a/mecon/etl/account_statements.py
+++ b/mecon/etl/account_statements.py
@@ -18,7 +18,7 @@ from mecon.etl import transformers
 # from mecon.etl.true_layer import TrueLayerAccount, TrueLayerAPIHandler
 from mecon.etl.true_layer_client_by_o3 import TrueLayerClient
 from mecon.etl.trading212_client_by_o3 import Trading212Client
-from mecon.etl.monzo_api_client import MonzoClient
+from mecon.etl.monzo_api_client import MonzoClient, MonzoCredentialsError
 from mecon.settings import DictFile
 from mecon.utils.datatype_transformations import json_to_csv
 from mecon.utils.datatype_transformations import normalise_df_column_names
@@ -345,7 +345,12 @@ class MonzoAPIStatements(APIAccountStatementsSource):
         fetch_datetime = datetime.now().date()
         fetch_job_id = str(uuid.uuid4())
 
-        df = self.api_handler.download_full_history(since=since)
+        try:
+            df = self.api_handler.download_full_history(since=since)
+        except MonzoCredentialsError as e:
+            logging.error(f"{self.__class__.__name__}: {e}")
+            return
+
         if len(df) == 0:
             logging.info(
                 f"{self.__class__.__name__}: No transactions fetched for Monzo-API since {self}. No file added to {self.dir_name}.")

--- a/mecon/etl/account_statements.py
+++ b/mecon/etl/account_statements.py
@@ -18,7 +18,7 @@ from mecon.etl import transformers
 # from mecon.etl.true_layer import TrueLayerAccount, TrueLayerAPIHandler
 from mecon.etl.true_layer_client_by_o3 import TrueLayerClient
 from mecon.etl.trading212_client_by_o3 import Trading212Client
-from mecon.etl.monzo_api_client import MonzoClient, MonzoCredentialsError
+from mecon.etl.monzo_api_client import MonzoClient
 from mecon.settings import DictFile
 from mecon.utils.datatype_transformations import json_to_csv
 from mecon.utils.datatype_transformations import normalise_df_column_names
@@ -345,11 +345,7 @@ class MonzoAPIStatements(APIAccountStatementsSource):
         fetch_datetime = datetime.now().date()
         fetch_job_id = str(uuid.uuid4())
 
-        try:
-            df = self.api_handler.download_full_history(since=since)
-        except MonzoCredentialsError as e:
-            logging.error(f"{self.__class__.__name__}: {e}")
-            return
+        df = self.api_handler.download_full_history(since=since)
 
         if len(df) == 0:
             logging.info(

--- a/mecon/etl/monzo_api_client.py
+++ b/mecon/etl/monzo_api_client.py
@@ -8,6 +8,7 @@ from monzo.authentication import Authentication
 from monzo.endpoints.account import Account
 from monzo.monzo import Monzo
 from monzo.errors import ForbiddenError, BadRequestError
+from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError
 
 from mecon.settings import DictFile
 
@@ -87,7 +88,13 @@ class MonzoClient:
 
     def refresh_token(self):
         logging.info("Refreshing token...")
-        self.monzo_auth.refresh_access()
+        try:
+            self.monzo_auth.refresh_access()
+        except Exception as e:
+            raise MonzoCredentialsError(
+                "Could not refresh the Monzo access token. "
+                "Please re-authenticate to obtain new credentials."
+            ) from e
         self._refresh_token_in_creds()
         logging.info("Refreshing token... Done")
 
@@ -161,6 +168,10 @@ class MonzoClient:
             end_dt = min(window_end, now_dt)
             return end_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
+        # Ensure we have a valid access token before making any requests
+        now_ts = datetime.datetime.now().timestamp()
+        if not self.monzo_auth.access_token or self.monzo_auth.access_token_expiry <= now_ts:
+            self.refresh_token()
         monzo = self._new_monzo_client()
 
         # Normalize the incoming 'since' to second precision Z
@@ -201,6 +212,21 @@ class MonzoClient:
                     continue
                 # Other 400s: re-raise so you can see them
                 raise
+            except InvalidClientIdError as e:
+                logging.info(f"Monzo error ({type(e).__name__}): {e}. Trying a token refresh and retry...")
+                try:
+                    self.refresh_token()
+                    monzo = self._new_monzo_client()
+                    transactions = monzo.get_transactions(
+                        account_id,
+                        before=before,
+                        since=since,
+                        limit=min(int(batch_size), 100)
+                    )
+                except (InvalidClientIdError, MonzoCredentialsError) as err:
+                    raise MonzoCredentialsError(
+                        "Could not refresh the Monzo access token. Please re-authenticate to obtain new credentials."
+                    ) from err
             except ForbiddenError as e:
                 # Verification required / SCA window etc.
                 logging.info(f"Monzo error ({type(e).__name__}): {e}. Trying a token refresh and retry...")

--- a/tests/unit_tests/test_monzo_api_client.py
+++ b/tests/unit_tests/test_monzo_api_client.py
@@ -1,0 +1,54 @@
+import json
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from mecon.settings import DictFile
+from mecon.etl.monzo_api_client import MonzoClient, MonzoCredentialsError
+from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError
+from monzo.authentication import Authentication
+
+
+def _make_creds(tmp_path):
+    creds_path = tmp_path / "creds.json"
+    creds_path.write_text(json.dumps({
+        "monzo-api": {
+            "client_id": "id",
+            "client_secret": "secret",
+            "redirect_url": "http://localhost",
+            "token": {
+                "access_token": "token",
+                "expiry": time.time() + 3600,
+                "refresh_token": "refresh",
+            },
+        }
+    }))
+    return DictFile(creds_path)
+
+
+def test_refresh_token_failure_raises_credentials_error(tmp_path, monkeypatch):
+    creds = _make_creds(tmp_path)
+    client = MonzoClient(creds)
+
+    def boom(self):
+        raise Exception("boom")
+
+    monkeypatch.setattr(Authentication, "refresh_access", boom)
+
+    with pytest.raises(MonzoCredentialsError):
+        client.refresh_token()
+
+
+def test_download_history_invalid_client_raises_credentials_error(tmp_path, monkeypatch):
+    creds = _make_creds(tmp_path)
+    client = MonzoClient(creds)
+
+    mock_monzo = MagicMock()
+    mock_monzo.get_transactions.side_effect = [InvalidClientIdError("bad"), InvalidClientIdError("bad")]
+
+    monkeypatch.setattr(client, "_new_monzo_client", lambda: mock_monzo)
+    monkeypatch.setattr(client, "refresh_token", lambda: None)
+
+    with pytest.raises(MonzoCredentialsError):
+        client.download_accounts_transaction_history("acc")

--- a/tests/unit_tests/test_monzo_api_client.py
+++ b/tests/unit_tests/test_monzo_api_client.py
@@ -68,3 +68,7 @@ class TestMonzoAPIStatements(unittest.TestCase):
                 source.fetch()
 
             self.assertEqual(list(Path(tmp_dir).glob("*.csv")), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests/test_monzo_api_client.py
+++ b/tests/unit_tests/test_monzo_api_client.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from mecon.settings import DictFile
 from mecon.etl.monzo_api_client import MonzoClient, MonzoCredentialsError
+from mecon.etl.account_statements import MonzoAPIStatements
 from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError
 from monzo.authentication import Authentication
 
@@ -50,3 +51,20 @@ class TestMonzoApiClient(unittest.TestCase):
                 with patch.object(client, "refresh_token", return_value=None):
                     with self.assertRaises(MonzoCredentialsError):
                         client.download_accounts_transaction_history("acc")
+
+
+class TestMonzoAPIStatements(unittest.TestCase):
+    def test_fetch_handles_credentials_error(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mock_client = MagicMock()
+            mock_client.download_full_history.side_effect = MonzoCredentialsError("bad")
+            source = MonzoAPIStatements(
+                working_dir=tmp_dir,
+                trans_transformer=MagicMock(),
+                api_handler=mock_client,
+            )
+
+            result = source.fetch()
+
+            self.assertIsNone(result)
+            self.assertEqual(list(Path(tmp_dir).glob("*.csv")), [])

--- a/tests/unit_tests/test_monzo_api_client.py
+++ b/tests/unit_tests/test_monzo_api_client.py
@@ -54,7 +54,7 @@ class TestMonzoApiClient(unittest.TestCase):
 
 
 class TestMonzoAPIStatements(unittest.TestCase):
-    def test_fetch_handles_credentials_error(self):
+    def test_fetch_propagates_credentials_error(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             mock_client = MagicMock()
             mock_client.download_full_history.side_effect = MonzoCredentialsError("bad")
@@ -64,7 +64,7 @@ class TestMonzoAPIStatements(unittest.TestCase):
                 api_handler=mock_client,
             )
 
-            result = source.fetch()
+            with self.assertRaises(MonzoCredentialsError):
+                source.fetch()
 
-            self.assertIsNone(result)
             self.assertEqual(list(Path(tmp_dir).glob("*.csv")), [])

--- a/tests/unit_tests/test_monzo_api_client.py
+++ b/tests/unit_tests/test_monzo_api_client.py
@@ -1,8 +1,9 @@
 import json
+import tempfile
 import time
-from unittest.mock import MagicMock
-
-import pytest
+from pathlib import Path
+import unittest
+from unittest.mock import MagicMock, patch
 
 from mecon.settings import DictFile
 from mecon.etl.monzo_api_client import MonzoClient, MonzoCredentialsError
@@ -10,8 +11,8 @@ from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError
 from monzo.authentication import Authentication
 
 
-def _make_creds(tmp_path):
-    creds_path = tmp_path / "creds.json"
+def _make_creds(tmp_dir):
+    creds_path = Path(tmp_dir) / "creds.json"
     creds_path.write_text(json.dumps({
         "monzo-api": {
             "client_id": "id",
@@ -27,28 +28,25 @@ def _make_creds(tmp_path):
     return DictFile(creds_path)
 
 
-def test_refresh_token_failure_raises_credentials_error(tmp_path, monkeypatch):
-    creds = _make_creds(tmp_path)
-    client = MonzoClient(creds)
+class TestMonzoApiClient(unittest.TestCase):
+    def test_refresh_token_failure_raises_credentials_error(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            creds = _make_creds(tmp_dir)
+            client = MonzoClient(creds)
 
-    def boom(self):
-        raise Exception("boom")
+            with patch.object(Authentication, "refresh_access", side_effect=Exception("boom")):
+                with self.assertRaises(MonzoCredentialsError):
+                    client.refresh_token()
 
-    monkeypatch.setattr(Authentication, "refresh_access", boom)
+    def test_download_history_invalid_client_raises_credentials_error(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            creds = _make_creds(tmp_dir)
+            client = MonzoClient(creds)
 
-    with pytest.raises(MonzoCredentialsError):
-        client.refresh_token()
+            mock_monzo = MagicMock()
+            mock_monzo.get_transactions.side_effect = [InvalidClientIdError("bad"), InvalidClientIdError("bad")]
 
-
-def test_download_history_invalid_client_raises_credentials_error(tmp_path, monkeypatch):
-    creds = _make_creds(tmp_path)
-    client = MonzoClient(creds)
-
-    mock_monzo = MagicMock()
-    mock_monzo.get_transactions.side_effect = [InvalidClientIdError("bad"), InvalidClientIdError("bad")]
-
-    monkeypatch.setattr(client, "_new_monzo_client", lambda: mock_monzo)
-    monkeypatch.setattr(client, "refresh_token", lambda: None)
-
-    with pytest.raises(MonzoCredentialsError):
-        client.download_accounts_transaction_history("acc")
+            with patch.object(client, "_new_monzo_client", return_value=mock_monzo):
+                with patch.object(client, "refresh_token", return_value=None):
+                    with self.assertRaises(MonzoCredentialsError):
+                        client.download_accounts_transaction_history("acc")


### PR DESCRIPTION
## Summary
- refresh access token up front and save new refresh token
- handle invalid-client OAuth refresh errors by prompting re-authentication
- cover Monzo client credential errors with high-level tests

## Testing
- `pytest tests/unit_tests/test_monzo_api_client.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx'; tests/unit_tests/test_statements.py Exception: For this tests to run 'test' dataset has to be present)*

------
https://chatgpt.com/codex/tasks/task_e_68b76d6ba1e08326811900745ece1411