### PR TITLE
Add sample dataset for statement/tag integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 /clipboard.py
 /misc/reports_history/
 
-/datasets/
+/datasets/*
+!/datasets/test_statements_and_tags/
+!/datasets/test_statements_and_tags/**
+!/datasets/test_statements_and_tags/**/*.csv
 /creds/
 /.env
 /.idea/
@@ -15,6 +18,7 @@ example_path
 /templates/
 /static/
 settings.json
+!/datasets/test_statements_and_tags/settings.json
 /misc/misc_scripts/
 /misc/
 /todo.txt

--- a/datasets/test_statements_and_tags/data/current/tags.csv
+++ b/datasets/test_statements_and_tags/data/current/tags.csv
@@ -1,0 +1,2 @@
+name,conditions_json,date_created
+Commute,"[{""description.lower"":{""contains"":""tfl""}}]",2024-03-01 00:00:00

--- a/datasets/test_statements_and_tags/data/statements/INVENG/invest_engine_transactions_2024.csv
+++ b/datasets/test_statements_and_tags/data/statements/INVENG/invest_engine_transactions_2024.csv
@@ -1,0 +1,4 @@
+datetime,amount,currency,description
+01/03/2024 09:00:00,250.00,GBP,Monthly deposit from HSBC
+08/03/2024 15:30:00,-75.50,GBP,ETF purchase VWRL
+19/03/2024 10:15:00,12.30,GBP,Dividend payout VWRL

--- a/datasets/test_statements_and_tags/data/statements/MonzoAPI/monzo_api_march_2024.csv
+++ b/datasets/test_statements_and_tags/data/statements/MonzoAPI/monzo_api_march_2024.csv
@@ -1,0 +1,4 @@
+id,created,local_currency,local_amount,amount,description,merchant,category
+tx_0001,2024-03-02T08:15:00.000Z,GBP,250000,250000,Monthly salary payment from ITV,None,income
+tx_0002,2024-03-04T07:45:00.000Z,GBP,-320,-320,TFL Travel - Zone 1 to 3,TfL,transport
+tx_0003,2024-03-05T18:20:00.000Z,GBP,-4520,-4520,Tesco Supermarket groceries,Tesco,shopping

--- a/datasets/test_statements_and_tags/data/statements/Trading212API/trading212_history_march_2024.csv
+++ b/datasets/test_statements_and_tags/data/statements/Trading212API/trading212_history_march_2024.csv
@@ -1,0 +1,3 @@
+id,time,total,currency_(total),action,ticker,quantity,price
+9001,2024-03-11 10:05:00,-150.00,GBP,Buy,VUSA,1,150.00
+9002,2024-03-25 07:30:00,5.25,GBP,Dividend,VUSA,0,5.25

--- a/datasets/test_statements_and_tags/data/statements/TrueLayerHSBC/truelayer_hsbc_march_2024.csv
+++ b/datasets/test_statements_and_tags/data/statements/TrueLayerHSBC/truelayer_hsbc_march_2024.csv
@@ -1,0 +1,4 @@
+transaction_id,timestamp,amount,currency,description,transaction_type,transaction_category
+hsbc_001,2024-03-01T08:00:00Z,3000.50,GBP,Salary payment from Deloitte,Credit,income
+hsbc_002,2024-03-03T10:30:00Z,-1200.00,GBP,Rent payment to Landlord,Debit,rent
+hsbc_003,2024-03-06T07:15:00Z,-45.60,GBP,TFL Travelcard renewal,Debit,transport

--- a/datasets/test_statements_and_tags/data/statements/TrueLayerHSBCSaver/truelayer_hsbc_saver_march_2024.csv
+++ b/datasets/test_statements_and_tags/data/statements/TrueLayerHSBCSaver/truelayer_hsbc_saver_march_2024.csv
@@ -1,0 +1,2 @@
+transaction_id,timestamp,amount,currency,description,transaction_type,transaction_category
+saver_001,2024-03-05T09:00:00Z,1.50,GBP,Monthly interest payment,Credit,interest

--- a/datasets/test_statements_and_tags/settings.json
+++ b/datasets/test_statements_and_tags/settings.json
@@ -1,0 +1,37 @@
+{
+    "CURRENT_DATASET": "test_statements_and_tags",
+    "links": {
+        "Comparisons": {
+            "Compare...": "http://127.0.0.1:8001/reports/compare/",
+            "Monthly basics": "http://127.0.0.1:8001/reports/compare?start_date=2024-03-01&end_date=2024-03-31&time_unit=month&compare_tags=Income,Rent,Super%20Market,Commute,Investments"
+        },
+        "Reports": {
+            "All clean": "http://127.0.0.1:8001/reports/tags?start_date=2024-03-01&end_date=2024-03-31&time_unit=month&filter_in_tags=All&filter_out_tags=My%20transfers",
+            "All latest transactions": "http://127.0.0.1:8001/reports/tags/?filter_in_tags=All&time_unit=month",
+            "Income": "http://127.0.0.1:8001/reports/tags/?filter_in_tags=Income&time_unit=month",
+            "Commute": "http://127.0.0.1:8001/reports/tags/?filter_in_tags=Commute&time_unit=month",
+            "New report...": "http://127.0.0.1:8001/reports/tags/",
+            "Tags graph": "http://127.0.0.1:8001/reports/tags_info/"
+        },
+        "Tagging": {
+            "Manually": "http://127.0.0.1:8002/edit_data/tags/manual/"
+        }
+    },
+    "sources": {
+        "HSBC": false,
+        "HSBCSVR": false,
+        "INVENG": true,
+        "Monzo": false,
+        "MonzoAPI": true,
+        "Revolut": false,
+        "Trading212API": true,
+        "TRD212": false,
+        "TRD212_CASH_ISA": false,
+        "TrueLayerHSBC": true,
+        "TrueLayerHSBCSaver": false,
+        "TrueLayerRevolutEUR": false,
+        "TrueLayerRevolutGBP": false,
+        "TrueLayerRevolutHUF": false,
+        "TrueLayerRevolutRON": false
+    }
+}


### PR DESCRIPTION
## Summary
- add a committed test dataset with representative statements for InvestEngine, MonzoAPI, Trading212API, and TrueLayer HSBC sources
- seed the dataset with a commute tag and source-specific statements while keeping the HSBC saver data disabled in settings
- update .gitignore to allow the committed dataset to be tracked

## Testing
- not run (dataset-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9bc7a4b6c832681308a2e0e177e67