### PR TITLE
Refine manual tagging transactions table renderer

### DIFF
--- a/mecon/app/shiny_app.py
+++ b/mecon/app/shiny_app.py
@@ -113,7 +113,7 @@ def transactions_intersection_filtered_factory(
         ui.input_select(
             id='date_period_input_select',
             label='Select date period',
-            choices=['Last 30 days', 'Last 90 days', 'Last year', 'All'],
+            choices=['Last 30 days', 'Last 90 days', 'Last year', 'All'], # TODO last week, q1-4 (if exist), <2020, 2020, 2021, 2022, etc...
             selected=selected_period
         ),
         ui.input_date_range(

--- a/services/edit_data/manual_tagging_app.py
+++ b/services/edit_data/manual_tagging_app.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from itertools import chain
 
 import pandas as pd
 from shiny import App, Inputs, Outputs, Session, render, ui, reactive
@@ -23,6 +24,26 @@ shown_transactions = None
 
 DEFAULT_TIME_UNIT = 'month'
 PAGE_SIZE = 100
+
+app_ui = shiny_app.app_ui_factory(
+    ui.layout_sidebar(
+        ui.sidebar(
+            shiny_app.transactions_intersection_filtered_factory(
+                fixed_time_unit=True,
+                default_time_unit='none',
+            ),
+        ),
+        ui.page_fluid(
+            ui.card(
+                ui.card_header(
+                    ui.output_text(id='transactions_header_text'),
+                    ui.input_action_button(id='see_all_changes_button', label='See all changes')
+                ),
+                ui.card_body(ui.output_data_frame(id='transactions_output_df'))
+            ),
+        ),
+    )
+)
 
 TRANSACTION_TABLE_COLUMN_WIDTHS = {
     'Tx_ID': '10ch',
@@ -58,7 +79,8 @@ TRANSACTION_TABLE_BASE_STYLES = [
 ]
 
 
-def build_column_width_styles(column_names: list[str], width_overrides: dict[str, str | int], *, include_header: bool = True):
+def build_column_width_styles(column_names: list[str], width_overrides: dict[str, str | int], *,
+                              include_header: bool = True):
     if not width_overrides:
         return []
 
@@ -100,186 +122,78 @@ def combine_table_styles(*style_groups: list[dict] | dict | None):
 
 
 def render_table_customised_width(
-    df: pd.DataFrame,
-    *,
-    width: str | float | None = "100%",
-    height: str | float | None = "600px",
-    column_widths: dict[str, str | int] | None = None,
-    base_styles: list[dict] | None = None,
+        df: pd.DataFrame,
+        *,
+        width: str | float | None = "100%",
+        height: str | float | None = "600px",
+        column_widths: dict[str, str | int] | None = None,
+        base_styles: list[dict] | None = None,
 ):
     column_width_styles = build_column_width_styles(df.columns.tolist(), column_widths or {})
     resolved_base_styles = TRANSACTION_TABLE_BASE_STYLES if base_styles is None else base_styles
     table_styles = combine_table_styles(resolved_base_styles, column_width_styles)
 
-    return render.DataTable(
-        df,
-        width=width,
-        height=height,
-        filters=True,
-        selection_mode="none",
-        styles=table_styles,
-    )
+    # TODO solve bug and re-enable
+    # return render.DataTable(
+    #     df,
+    #     width=width,
+    #     height=height,
+    #     filters=True,
+    #     selection_mode="none",
+    #     styles=table_styles,
+    # )
+    return df
 
-app_ui = shiny_app.app_ui_factory(
-    ui.layout_sidebar(
-        ui.sidebar(
-            shiny_app.transactions_intersection_filtered_factory(),
-        ),
-        ui.page_fluid(
-            ui.card(
-                ui.card_header(ui.output_text(id='transactions_header_text')),
-                ui.card_body(ui.output_data_frame(id='transactions_output_df'))
-            ),
-        ),
-    )
-)
-
-
-# def _transform_id(id_str):
-#     return id_str.replace('.', '[dot]').replace('-', '_')
-#
-#
-# def new_transaction_row(transaction, all_tags):
-#     amount = transaction['amount']
-#     amount_str = f"{'⮝' if amount < 0 else '⮟'} {amount} GBP   " + \
-#                  (f"({transaction['amount_cur']} {transaction['currency']})" if transaction[
-#                                                                                     'currency'] != 'GBP' else '')
-#     _dt = transaction['datetime'].to_pydatetime()
-#     date_str, time = _dt.date().strftime('%a %d %B, %Y'), _dt.time()
-#     res_ui = ui.card(
-#         ui.row(
-#             ui.column(4, ui.h4(amount_str, style=f"color:{'red' if transaction['amount'] < 0 else 'green'}")),
-#             ui.column(6, ui.h3(f"📅{date_str} - 🕑{time}")),
-#             ui.column(2, ui.h6(transaction['id']), height='5px', style=f"background-color: grey")),
-#         ui.row(ui.column(12, ui.h4(ui.card(transaction['description'])))),
-#         ui.card_footer(ui.row(ui.h2(ui.input_selectize(id=f"tags_{transaction['id']}", label='Tags', multiple=True,
-#                                                        choices=[tag.name for tag in all_tags],
-#                                                        selected=transaction['tags'].split(','), width='100%')))),
-#         # max_height='10%',
-#         style="border-color: grey", id=transaction['id']
-#     )
-#     change_tracker.clear()
-#     return res_ui
-#
-#
-# def build_tag_choices(all_tags):
-#     return sorted([tag.name for tag in all_tags])
-#
-#
-# def filter_transactions_by_selected_tags(transactions: Transactions, selected_tags) -> Transactions:
-#     return transactions.containing_tags(selected_tags)
-#
-#
-# def paginate_transactions(transactions: Transactions, order_option: str, page_number: int, page_size: int):
-#     return utils.sort_and_filter_transactions_df(transactions, order_option, page_number, page_size)
-#
-#
-# def build_page_choices(transactions: Transactions, order_option: str, page_size: int):
-#     if order_option == 'Newest transactions':
-#         groups = transactions.group(groupings.WEEK)
-#         label = 'Choose week'
-#         ranges = [(str(week.date.min()), str(week.date.max())) for week in groups]
-#     elif order_option == 'Least tagged':
-#         groups = transactions.group(groupings.IndexGrouping.equal_size_groups(page_size, transactions.size()))
-#         label = f"Choose page (size: {page_size})"
-#         ranges = [(str(group.date.min()), str(group.date.max())) for group in groups]
-#     else:
-#         raise ValueError(f"Invalid ordering: {order_option}")
-#
-#     range_strings = {str(i): f"{i} ({rng[0]}, {rng[1]})" for i, rng in enumerate(ranges)}
-#     return label, range_strings
-#
-#
-# def clear_rendered_transactions(_shown_transactions):
-#     if _shown_transactions is None:
-#         return
-#     for _id in _shown_transactions['id']:
-#         ui.remove_ui(selector=f"#{_id}")
-#
-#
-# def register_selectize_change_handler(input_obj, transaction_id):
-#     def on_change():
-#         change_tracker.append(transaction_id)
-#
-#     reactive.effect(reactive.event(getattr(input_obj, f"tags_{transaction_id}"))(on_change))
-#
-#
-# def determine_tag_changes(current_transactions_df, input_obj):
-#     changed_transaction_ids = set(change_tracker[len(current_transactions_df):])
-#     old_changed_transactions_df = current_transactions_df[
-#         current_transactions_df['id'].isin(changed_transaction_ids)]
-#     new_tags = {_id: set(getattr(input_obj, f"tags_{_id}")()) for _id in changed_transaction_ids}
-#     old_tags = old_changed_transactions_df[['id', 'tags']].set_index('id').to_dict('index')
-#     old_tags = {_id: set(tags['tags'].split(',')) for _id, tags in old_tags.items()}
-#     added = {_id: new_tags[_id].difference(old_tags[_id]) for _id in changed_transaction_ids if
-#              len(new_tags[_id].difference(old_tags[_id]))}
-#     removed = {_id: old_tags[_id].difference(new_tags[_id]) for _id in changed_transaction_ids if
-#                len(old_tags[_id].difference(new_tags[_id]))}
-#     return added, removed
-#
-#
-# def build_review_changes_modal(added, removed):
-#     added_message = '\n'.join(
-#         [' * <span style="color:green">' + f"{', '.join(tags)} added to transaction \'{tid}\'</span>" for tid, tags in
-#          added.items()])
-#     removed_message = '\n'.join(
-#         [' * <span style="color:red">' + f"{', '.join(tags)} removed from transaction \'{tid}\'</span>" for tid, tags in
-#          removed.items()])
-#
-#     return ui.modal(
-#         ui.markdown(f'{added_message}\n{removed_message}'),
-#         title="Review changes before saving",
-#         easy_close=True,
-#         size='xl',
-#         footer=ui.input_action_button(id='save_button', label='Save'),
-#     )
 
 
 def construct_amount_str(transaction_series):
     transaction_dict = transaction_series.to_dict()
-    is_amount_positive = transaction_dict['amount']>0
+    is_amount_positive = transaction_dict['amount'] > 0
     amount_str = f"{abs(transaction_dict['amount']):.1f}"
     amount_full_info_str = f"{'⮝' if is_amount_positive else '⮟'} {amount_str} GBP   " + \
-                 (f"({transaction_dict['amount_cur']} {transaction_dict['currency']})" if transaction_dict[
-                                                                                    'currency'] != 'GBP' else '')
+                           (f"({transaction_dict['amount_cur']} {transaction_dict['currency']})" if transaction_dict[
+                                                                                                        'currency'] != 'GBP' else '')
 
     return amount_full_info_str.strip()
 
 
 def ui_id_transformation(id_str, short_str_len=5):
-    id_str_short = id_str[:min(short_str_len, len(id_str)) - 1]+'...'
+    id_str_short = id_str[:min(short_str_len, len(id_str)) - 1] + '...'
     res = ui.tooltip(ui.HTML(f"<label>{id_str_short}</label>"), id_str, placement='top')
     return res
 
+
 def ui_description_transformation(desc_str, short_str_len=10):
-    desc_str_short = desc_str[:min(short_str_len, len(desc_str)) - 1]+'...'
+    desc_str_short = desc_str[:min(short_str_len, len(desc_str)) - 1] + '...'
     res = ui.tooltip(ui.HTML(f"<label>{desc_str_short}</label>"), desc_str, placement='top')
     return res
 
-def sanitize_input_id(raw_id: str) -> str:
-    """Convert transaction identifiers into valid Shiny input ids."""
 
-    sanitized = re.sub(r'[^0-9a-zA-Z_]', '_', str(raw_id))
-    if not sanitized:
-        sanitized = 'tags_input'
-    if sanitized[0].isdigit():
-        sanitized = f"_{sanitized}"
+def sanitize_tx_id(raw_tx_id: str) -> str:
+    """Convert transaction identifiers into valid Shiny input ids."""
+    sanitized = raw_tx_id.replace('-', '_hyphen_').replace('.', '_dot_')
     return sanitized
 
 
-def ui_tags_transformation(transaction_id: str, tags_str: str, tag_choices: list[str]):
-    tags_list = [tag.strip() for tag in tags_str.split(',') if tag.strip()] if tags_str else []
-    selectize_id = sanitize_input_id(f"tags_{transaction_id}")
+def desanitize_tx_id(sanitized_tx_id: str) -> str:
+    """Convert sanitized identifiers into transaction ids."""
+    desanitized = sanitized_tx_id.replace('_hyphen_', '-').replace('_dot_', '.')
+    return desanitized
+
+
+def ui_tags_transformation(transaction_id: str, current_tags: set[str], tag_choices: set[str], selectize_id: str):
+    selected_tags = []
+    available_tags = tag_choices.difference(current_tags)
     selectize_input = ui.input_selectize(
         id=selectize_id,
         label=None,
-        choices=tag_choices,
-        selected=tags_list,
+        choices=list(available_tags),
+        selected=selected_tags,
         multiple=True,
         width='100%',
         remove_button=True,
         options={
-            'placeholder': 'Search or add tags…',
+            'placeholder': 'Add tags...',
         }
     )
 
@@ -291,8 +205,11 @@ def ui_tags_transformation(transaction_id: str, tags_str: str, tag_choices: list
     return container
 
 
-def enhance_transactions_df(df_tx, tag_choices):
+def enhance_transactions_df(df_tx, all_tags: set[str]):
+    logging.info(f"Enhancing transactions df with {df_tx.shape[0]} rows")
     df_ench = df_tx.copy()
+    df_ench['current_tags'] = df_ench['tags'].apply(lambda tags: ','.join(sorted(tags.split(','))))
+    df_ench['tags'] = df_ench['tags'].apply(lambda tags: set(tags.split(',')))
     df_ench['date'] = df_tx['datetime'].apply(lambda dt: dt.date().strftime('%Y-%m-%d'))
     df_ench['time'] = df_tx['datetime'].apply(lambda dt: dt.time().strftime('%H:%M:%S'))
     df_ench['amount'] = df_tx.apply(lambda row: construct_amount_str(row), axis=1)
@@ -301,20 +218,41 @@ def enhance_transactions_df(df_tx, tag_choices):
 
     df_ench['Tx_ID'] = df_ench['id'].apply(ui_id_transformation)
     df_ench['short_desc'] = df_tx['description'].apply(ui_description_transformation)
-    df_ench['select_tags'] = df_tx.apply(
-        lambda row: ui_tags_transformation(row['id'], row['tags'], tag_choices),
+    df_ench['selectize_id'] = df_tx['id'].apply(lambda tx_id: f"selectize_" + sanitize_tx_id(tx_id))
+    df_ench['add_tags'] = df_ench.apply(
+        lambda row: ui_tags_transformation(row['id'], row['tags'], all_tags, row['selectize_id']),
+        # TODO all non built in tags
         axis=1
     )
 
-
-    cols_to_keep = ['Tx_ID', 'amount', 'date', 'time', 'week_id', 'n_tags', 'select_tags', 'short_desc']
+    cols_to_keep = ['Tx_ID', 'amount', 'date', 'time', 'week_id', 'n_tags', 'current_tags', 'add_tags', 'short_desc']
     df_res = df_ench[cols_to_keep]
     return df_res
+
+
+def transform_tag_diffs(tag_diffs):
+    tag_diffs_df = pd.DataFrame(tag_diffs)
+    tag_diffs_df['id'] = tag_diffs_df['selectize_id'].apply(lambda sid: desanitize_tx_id(sid.replace('selectize_', '')))
+    tags = set(chain(*tag_diffs_df['changes'].tolist()))
+    dfs = []
+    for tag in tags:
+        tag_df = tag_diffs_df[tag_diffs_df['changes'].apply(lambda changes: tag in changes)]
+        tag_df['tag'] = tag
+        dfs.append(tag_df[['tag', 'id']])
+    df_merged = pd.concat(dfs)
+
+    transformed_df = df_merged.groupby('tag').agg({'id': list}).reset_index()
+    transformed_dict = {k:v['id'] for k, v in transformed_df.set_index('tag').to_dict('index').items()}
+    return transformed_dict
 
 
 def server(input: Inputs, output: Outputs, session: Session):
     data_manager = shiny_app.create_data_manager()
     all_tags = data_manager.all_tags()
+
+    custom_tags = set(data_manager.custom_tags_df['name'])
+
+    addable_tags_set = {tag for tag in custom_tags}
 
     transactions = data_manager.get_transactions()
 
@@ -340,15 +278,14 @@ def server(input: Inputs, output: Outputs, session: Session):
         start_date, end_date = filtered_transactions_tx.date_range()
         unique_tags = filtered_transactions_tx.all_tags()
 
-        title = f"{len(filtered_transactions_df)} transactions from {start_date} to {end_date} containing {len(unique_tags)}" \
-                # f" page={input.page_number_select()}," \
-                # f" page_size={PAGE_SIZE}"
+        title = f"{len(filtered_transactions_df)} transactions from {start_date} to {end_date} containing {len(unique_tags)} unique tags" \
+            # f" page={input.page_number_select()}," \
+        # f" page_size={PAGE_SIZE}"
         return title
 
     @render.data_frame
     def transactions_output_df():
-        tag_choices = sorted({tag.name for tag in all_tags})
-        df = enhance_transactions_df(filtered_transactions_calc().dataframe(), tag_choices)
+        df = enhance_transactions_df(filtered_transactions_calc().dataframe(), addable_tags_set)
         return render_table_customised_width(
             df,
             width='100%',
@@ -356,87 +293,46 @@ def server(input: Inputs, output: Outputs, session: Session):
             column_widths=TRANSACTION_TABLE_COLUMN_WIDTHS,
         )
 
-    # @reactive.effect
-    # def load():
-    #     ui.update_selectize(
-    #         id='input_tags_select',
-    #         choices=build_tag_choices(all_tags)
-    #     )
-    #
-    # @reactive.calc
-    # def tag_filtered_transactions() -> Transactions:
-    #     logging.info(
-    #         f"Filtering transactions, order: UNKNOWN, tags subset: {','.join(input.input_tags_select())}, page: , window: ")
-    #     return filter_transactions_by_selected_tags(transactions, input.input_tags_select())
-    #
-    # @reactive.calc
-    # def filtered_transactions_df() -> pd.DataFrame:
-    #     # trans = tag_filtered_transactions()
-    #     trans = filtered_transactions()
-    #
-    #     transactions_dfs = paginate_transactions(
-    #         trans,
-    #         input.transaction_order_select(),
-    #         int(input.page_number_select()),
-    #         PAGE_SIZE,
-    #     )
-    #     transactions_dfs['id'] = transactions_dfs['id'].apply(_transform_id)
-    #
-    #     global shown_transactions
-    #     clear_rendered_transactions(shown_transactions)
-    #     shown_transactions = transactions_dfs
-    #
-    #     for i, transaction in transactions_dfs.iterrows():
-    #         ui.insert_ui(
-    #             ui=new_transaction_row(transaction, all_tags),
-    #             selector='#transactions_header_text',
-    #             where="beforeEnd",
-    #         )
-    #
-    #     for transaction_id in transactions_dfs['id']:
-    #         register_selectize_change_handler(input, transaction_id)
-    #
-    #     logging.info(f"Filtering Done")
-    #
-    #     return transactions_dfs
-    #
-    # def remove_transaction_rows():
-    #     global shown_transactions
-    #     clear_rendered_transactions(shown_transactions)
-    #     shown_transactions = None
-    #
-    # @reactive.effect
-    # @reactive.event(input.transaction_order_select)
-    # def _():
-    #     label, choices = build_page_choices(tag_filtered_transactions(), input.transaction_order_select(), PAGE_SIZE)
-    #     ui.update_select(id='page_number_select', label=label, choices=choices)
-    #
-    # @reactive.effect
-    # @reactive.event(input.page_number_select)
-    # def _():
-    #     logging.info(f"Changing page...")
-    #     remove_transaction_rows()
-    #
-    # @render.text
-    # def transactions_header_text():
-    #     return f"Transactions: {len(filtered_transactions_df())}," \
-    #            f" page={input.page_number_select()}," \
-    #            f" page_size={PAGE_SIZE}"
-    #
-    # @reactive.effect
-    # @reactive.event(input.review_and_save_button)
-    # def _():
-    #     global added_tags, removed_tags
-    #     added_tags, removed_tags = determine_tag_changes(filtered_transactions_df(), input)
-    #     ui.modal_show(build_review_changes_modal(added_tags, removed_tags))
-    #
-    # @reactive.effect
-    # @reactive.event(input.save_button)
-    # def save_changes():
-    #     global added_tags, removed_tags
-    #     utils.save_tag_changes(added_tags,
-    #                            removed_tags,
-    #                            data_manager)
+    def fetch_tag_diffs():
+        ids = filtered_transactions_calc().dataframe()['id'].apply(
+            lambda tx_id: f"selectize_" + tx_id.replace('-', '_').replace('.', '_')).tolist()
+        tag_diffs = []
+        logging.info(f"{dir(input)=}")
+        for selectize_id in ids:
+            func = getattr(input, selectize_id)
+            try:
+                added_tags_info = {'selectize_id': selectize_id, 'changes': func()}
+                if len(added_tags_info['changes']) > 0:
+                    tag_diffs.append(added_tags_info)
+            except Exception as e:
+                logging.error(e)
+        return tag_diffs
+
+    @reactive.effect
+    @reactive.event(input.see_all_changes_button)
+    def see_all_changes_button():
+        # df = enhance_transactions_df(filtered_transactions_calc().dataframe(), addable_tags_set)
+
+        tag_diffs = fetch_tag_diffs()
+        changes_per_tag = transform_tag_diffs(tag_diffs)
+
+        m = ui.modal(
+            ui.markdown(f"This is a somewhat important message. ({len(tag_diffs)=})  {changes_per_tag}"),
+            title="Review changes before saving",
+            easy_close=True,
+            size='xl',
+            footer=ui.input_action_button(id='save_button', label='Save'),
+        )
+        ui.modal_show(m)
+
+    @reactive.effect
+    @reactive.event(input.save_button)
+    def save_changes():
+        tag_diffs = fetch_tag_diffs()
+        changes_per_tag = transform_tag_diffs(tag_diffs)
+        utils.save_tag_changes(changes_per_tag, data_manager)
+
+
 
 
 manual_tagging_app = App(app_ui, server)

--- a/services/edit_data/manual_tagging_app.py
+++ b/services/edit_data/manual_tagging_app.py
@@ -221,7 +221,6 @@ def enhance_transactions_df(df_tx, all_tags: set[str]):
     df_ench['selectize_id'] = df_tx['id'].apply(lambda tx_id: f"selectize_" + sanitize_tx_id(tx_id))
     df_ench['add_tags'] = df_ench.apply(
         lambda row: ui_tags_transformation(row['id'], row['tags'], all_tags, row['selectize_id']),
-        # TODO all non built in tags
         axis=1
     )
 
@@ -248,19 +247,19 @@ def transform_tag_diffs(tag_diffs):
 
 def server(input: Inputs, output: Outputs, session: Session):
     data_manager = shiny_app.create_data_manager()
-    all_tags = data_manager.all_tags()
+    # all_tags = data_manager.all_tags()
 
     custom_tags = set(data_manager.custom_tags_df['name'])
 
     addable_tags_set = {tag for tag in custom_tags}
 
-    transactions = data_manager.get_transactions()
-
-    filter_url_params = shiny_app.filter_url_params_function_factory(
-        input,
-        output,
-        session,
-        data_manager)
+    # transactions = data_manager.get_transactions()
+    #
+    # filter_url_params = shiny_app.filter_url_params_function_factory(
+    #     input,
+    #     output,
+    #     session,
+    #     data_manager)
 
     (get_filter_params,
      default_transactions,

--- a/services/edit_data/manual_tagging_app.py
+++ b/services/edit_data/manual_tagging_app.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import pandas as pd
 from shiny import App, Inputs, Outputs, Session, render, ui, reactive
@@ -22,6 +23,102 @@ shown_transactions = None
 
 DEFAULT_TIME_UNIT = 'month'
 PAGE_SIZE = 100
+
+TRANSACTION_TABLE_COLUMN_WIDTHS = {
+    'Tx_ID': '10ch',
+    'amount': '14ch',
+    'date': '12ch',
+    'time': '10ch',
+    'week_id': '16ch',
+    'n_tags': '8ch',
+    'select_tags': '26ch',
+    'short_desc': '28ch',
+}
+
+TRANSACTION_TABLE_BASE_STYLES = [
+    {
+        "location": "header",
+        "style": {
+            "backgroundColor": "#212529",
+            "color": "#f8f9fa",
+            "fontWeight": "600",
+            "fontSize": "13px",
+            "textTransform": "uppercase",
+        },
+    },
+    {
+        "location": "body",
+        "style": {
+            "backgroundColor": "#f8f9fa",
+            "borderBottom": "1px solid #dee2e6",
+            "fontSize": "14px",
+            "color": "#212529",
+        },
+    },
+]
+
+
+def build_column_width_styles(column_names: list[str], width_overrides: dict[str, str | int], *, include_header: bool = True):
+    if not width_overrides:
+        return []
+
+    name_to_index = {name: idx for idx, name in enumerate(column_names)}
+    styles: list[dict] = []
+
+    for column_name, width in width_overrides.items():
+        if column_name not in name_to_index or width is None:
+            continue
+
+        column_index = name_to_index[column_name]
+        width_value = str(width)
+        style_payload = {
+            "cols": [column_index],
+            "style": {
+                "minWidth": width_value,
+                "maxWidth": width_value,
+                "whiteSpace": "nowrap",
+            },
+        }
+
+        styles.append({"location": "body", **style_payload})
+        if include_header:
+            styles.append({"location": "header", **style_payload})
+
+    return styles
+
+
+def combine_table_styles(*style_groups: list[dict] | dict | None):
+    combined: list[dict] = []
+    for styles in style_groups:
+        if not styles:
+            continue
+        if isinstance(styles, list):
+            combined.extend(styles)
+        else:
+            combined.append(styles)
+    return combined
+
+
+def render_table_customised_width(
+    df: pd.DataFrame,
+    *,
+    width: str | float | None = "100%",
+    height: str | float | None = "600px",
+    column_widths: dict[str, str | int] | None = None,
+    base_styles: list[dict] | None = None,
+):
+    column_width_styles = build_column_width_styles(df.columns.tolist(), column_widths or {})
+    resolved_base_styles = TRANSACTION_TABLE_BASE_STYLES if base_styles is None else base_styles
+    table_styles = combine_table_styles(resolved_base_styles, column_width_styles)
+
+    return render.DataTable(
+        df,
+        width=width,
+        height=height,
+        filters=True,
+        selection_mode="none",
+        styles=table_styles,
+    )
 
 app_ui = shiny_app.app_ui_factory(
     ui.layout_sidebar(
@@ -159,18 +256,42 @@ def ui_description_transformation(desc_str, short_str_len=10):
     res = ui.tooltip(ui.HTML(f"<label>{desc_str_short}</label>"), desc_str, placement='top')
     return res
 
-def ui_tags_transformation(tags_Str):
-    tags_list = tags_Str.split(',')
-    res = ui.input_selectize(
-        "tags_selectize",
-        "tags...",
-        tags_list,
+def sanitize_input_id(raw_id: str) -> str:
+    """Convert transaction identifiers into valid Shiny input ids."""
+
+    sanitized = re.sub(r'[^0-9a-zA-Z_]', '_', str(raw_id))
+    if not sanitized:
+        sanitized = 'tags_input'
+    if sanitized[0].isdigit():
+        sanitized = f"_{sanitized}"
+    return sanitized
+
+
+def ui_tags_transformation(transaction_id: str, tags_str: str, tag_choices: list[str]):
+    tags_list = [tag.strip() for tag in tags_str.split(',') if tag.strip()] if tags_str else []
+    selectize_id = sanitize_input_id(f"tags_{transaction_id}")
+    selectize_input = ui.input_selectize(
+        id=selectize_id,
+        label=None,
+        choices=tag_choices,
+        selected=tags_list,
         multiple=True,
-    ),
-    return res
+        width='100%',
+        remove_button=True,
+        options={
+            'placeholder': 'Search or add tags…',
+        }
+    )
+
+    container = ui.div(
+        selectize_input,
+        {'class': 'transaction-tags-selectize', 'data-transaction-id': str(transaction_id)}
+    )
+
+    return container
 
 
-def enhance_transactions_df(df_tx):
+def enhance_transactions_df(df_tx, tag_choices):
     df_ench = df_tx.copy()
     df_ench['date'] = df_tx['datetime'].apply(lambda dt: dt.date().strftime('%Y-%m-%d'))
     df_ench['time'] = df_tx['datetime'].apply(lambda dt: dt.time().strftime('%H:%M:%S'))
@@ -180,7 +301,10 @@ def enhance_transactions_df(df_tx):
 
     df_ench['Tx_ID'] = df_ench['id'].apply(ui_id_transformation)
     df_ench['short_desc'] = df_tx['description'].apply(ui_description_transformation)
-    df_ench['select_tags'] = df_tx['tags'].apply(ui_tags_transformation)
+    df_ench['select_tags'] = df_tx.apply(
+        lambda row: ui_tags_transformation(row['id'], row['tags'], tag_choices),
+        axis=1
+    )
 
 
     cols_to_keep = ['Tx_ID', 'amount', 'date', 'time', 'week_id', 'n_tags', 'select_tags', 'short_desc']
@@ -223,8 +347,14 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     @render.data_frame
     def transactions_output_df():
-        df = enhance_transactions_df(filtered_transactions_calc().dataframe())
-        return shiny_app.render_table_standard(df)
+        tag_choices = sorted({tag.name for tag in all_tags})
+        df = enhance_transactions_df(filtered_transactions_calc().dataframe(), tag_choices)
+        return render_table_customised_width(
+            df,
+            width='100%',
+            height='600px',
+            column_widths=TRANSACTION_TABLE_COLUMN_WIDTHS,
+        )
 
     # @reactive.effect
     # def load():

--- a/services/edit_data/utils.py
+++ b/services/edit_data/utils.py
@@ -7,20 +7,9 @@ from mecon.data import groupings
 from mecon.data.transactions import Transactions
 
 
-def save_tag_changes(added_tags, removed_tags, data_manager):
-    def transform_changes_dict(_dict):
-        all_changes = []
-        for tid, tags in _dict.items():
-            for tag in tags:
-                all_changes.append({'id': tid, 'tag': tag})
-        tag_oriented_changes = pd.DataFrame(all_changes).groupby(['tag']).agg({'id': list}).to_dict(orient='index')
-        tag_oriented_changes = {_tag_name: _ids['id'] for _tag_name, _ids in tag_oriented_changes.items()}
-        return tag_oriented_changes
-
-    logging.info(f"Saving changes: {len(added_tags)} additions and {len(removed_tags)} removals/")
-
-    ids_added_to_tags = transform_changes_dict(added_tags)
-    for tag_name, ids in ids_added_to_tags.items():
+def save_tag_changes(changes_per_tag, data_manager):
+    # TODO add unit tests, docstrings and typehints
+    for tag_name, ids in changes_per_tag.items():
         tag_object = data_manager.get_tag(tag_name)
         new_tag = tag_helpers.add_rule_for_id(tag_object, ids)
         data_manager.update_tag(new_tag)

--- a/tests/tests_with_datasets/test_shiny_app_helpers.py
+++ b/tests/tests_with_datasets/test_shiny_app_helpers.py
@@ -23,10 +23,10 @@ from mecon.etl.dataset import Dataset
 @pytest.fixture
 def dataset_manager(tmp_path, monkeypatch):
     datasets_source = (
-        Path(__file__).resolve().parents[1]
-        / "tests_with_datasets"
-        / "datasets"
-        / "test_statements_and_tags"
+            Path(__file__).resolve().parents[1]
+            / "tests_with_datasets"
+            / "datasets"
+            / "test_statements_and_tags"
     )
 
     datasets_root = tmp_path / "datasets_root"
@@ -246,19 +246,50 @@ def test_parse_condition_value(shiny_helpers):
 #     assert "Choose page" in label
 #     assert isinstance(choices, dict) and choices
 
+def test_sanitize_tx_id(shiny_helpers):
+    assert shiny_helpers.manual_tagging.sanitize_tx_id('test_id1') == 'test_id1'
+    assert shiny_helpers.manual_tagging.sanitize_tx_id('test_id_with_-_in_it') == 'test_id_with__hyphen__in_it'
+    assert shiny_helpers.manual_tagging.sanitize_tx_id('test_id_with_._in_it') == 'test_id_with__dot__in_it'
+
+def test_desanitize_tx_id(shiny_helpers):
+    assert shiny_helpers.manual_tagging.desanitize_tx_id('test_id1') == 'test_id1'
+    assert shiny_helpers.manual_tagging.desanitize_tx_id('test_id_with__hyphen__in_it') == 'test_id_with_-_in_it'
+    assert shiny_helpers.manual_tagging.desanitize_tx_id('test_id_with__dot__in_it') == 'test_id_with_._in_it'
+
+
 def test_construct_amount_str(dataset_manager, shiny_helpers):
     _, manager, _ = dataset_manager
     df = manager.get_transactions().dataframe()
-    amount_strs = df.apply(shiny_helpers.manual_tagging.construct_amount_str, axis=1)
-    breakpoint()
+    amount_strs = df.apply(shiny_helpers.manual_tagging.construct_amount_str, axis=1).tolist()
+    expected_amount_strs = ['⮝ 3000.5 GBP', '⮝ 250.0 GBP', '⮝ 2500.0 GBP', '⮟ 1200.0 GBP', '⮟ 3.2 GBP', '⮟ 45.2 GBP', '⮟ 45.6 GBP', '⮟ 75.5 GBP', '⮟ 150.0 GBP', '⮝ 12.3 GBP', '⮝ 5.2 GBP']
+    assert amount_strs == expected_amount_strs
 
 
 def test_enhance_transactions_df(dataset_manager, shiny_helpers):
     _, manager, _ = dataset_manager
     df = manager.get_transactions().dataframe()
-    tag_choices = [tag.name for tag in manager.all_tags()]
-    df_enhanced = shiny_helpers.manual_tagging.enhance_transactions_df(df, tag_choices)
-    breakpoint()
+    all_tags = {tag.name for tag in manager.all_tags()}
+    df_enhanced = shiny_helpers.manual_tagging.enhance_transactions_df(df, all_tags)
+    assert len(df_enhanced.columns) == 9
+    assert df_enhanced.columns.tolist() == ['Tx_ID', 'amount', 'date', 'time', 'week_id', 'n_tags', 'current_tags', 'add_tags', 'short_desc']
+
+
+def test_transform_tag_diffs(shiny_helpers):
+    example_tag_diffs = [
+        {'selectize_id': 'selectize_tx_id1', 'changes': ('tag1',)},
+        {'selectize_id': 'selectize_tx_id2', 'changes': ('tag2',)},
+        {'selectize_id': 'selectize_tx_id3', 'changes': ('tag3', 'tag4', 'tag1')}]
+
+
+    expected_changes_per_tag = {
+        'tag1': ['tx_id1', 'tx_id3'],
+        'tag2': ['tx_id2'],
+        'tag3': ['tx_id3'],
+        'tag4': ['tx_id3'],
+    }
+
+    changes_per_tag = shiny_helpers.manual_tagging.transform_tag_diffs(example_tag_diffs)
+    assert changes_per_tag == expected_changes_per_tag
 
 
 def test_build_tags_table(dataset_manager, shiny_helpers):

--- a/tests/tests_with_datasets/test_shiny_app_helpers.py
+++ b/tests/tests_with_datasets/test_shiny_app_helpers.py
@@ -256,7 +256,8 @@ def test_construct_amount_str(dataset_manager, shiny_helpers):
 def test_enhance_transactions_df(dataset_manager, shiny_helpers):
     _, manager, _ = dataset_manager
     df = manager.get_transactions().dataframe()
-    df_enhanced = shiny_helpers.manual_tagging.enhance_transactions_df(df)
+    tag_choices = [tag.name for tag in manager.all_tags()]
+    df_enhanced = shiny_helpers.manual_tagging.enhance_transactions_df(df, tag_choices)
     breakpoint()
 
 


### PR DESCRIPTION
## Summary
- render transaction tags as proper selectize inputs with sanitized ids so the controls display correctly inside the table
- provide a manual-tagging-specific table renderer with configurable column widths and styling instead of altering shared helpers
- restore the shared Shiny table utilities to their previous behavior to avoid changes leaking into other modules

## Testing
- not run (existing breakpoints in the test suite prevent execution)


------
https://chatgpt.com/codex/tasks/task_e_68ebadf71c1c8326b47b0fb52322a18d