### PR TITLE
Improve Shiny filter initialization

### DIFF
--- a/mecon/app/shiny_app.py
+++ b/mecon/app/shiny_app.py
@@ -197,15 +197,34 @@ def filter_url_params_function_factory(input: Inputs,
                                 session: Session,
                                 data_manager: WorkingDataManager, ):
 
+    url_params = url_params_function_factory(input, output, session, data_manager)
+
+    def _get_single_param(params: dict, key: str, default=None):
+        values = params.get(key)
+        if not values:
+            return default
+        return values[0]
+
+    def _parse_date(value: str | None):
+        if value is None or len(value) == 0:
+            return None
+        try:
+            return datetime.date.fromisoformat(value)
+        except ValueError:
+            logging.warning(f"Invalid date provided for '{value}', ignoring")
+            return None
+
     @reactive.calc
     def filter_url_params():
-        _url_params = url_params_function_factory(input, output, session, data_manager)()
+        _raw_url_params = url_params()
         params = {}
-        params['filter_in_tags'] = _url_params.get('filter_in_tags', [''])[0]
-        params['filter_in_tags'] = params['filter_in_tags'].split(',') if len(params['filter_in_tags']) > 0 else []
-        params['filter_out_tags'] = _url_params.get('filter_out_tags', [''])[0]
-        params['filter_out_tags'] = params['filter_out_tags'].split(',') if len(params['filter_out_tags']) > 0 else []
-        params['time_unit'] = _url_params.get('time_unit', DEFAULT_FILTER_TIME_UNIT)
+        filter_in_tags_raw = _get_single_param(_raw_url_params, 'filter_in_tags', '')
+        params['filter_in_tags'] = filter_in_tags_raw.split(',') if len(filter_in_tags_raw) > 0 else []
+        filter_out_tags_raw = _get_single_param(_raw_url_params, 'filter_out_tags', '')
+        params['filter_out_tags'] = filter_out_tags_raw.split(',') if len(filter_out_tags_raw) > 0 else []
+        params['time_unit'] = _get_single_param(_raw_url_params, 'time_unit', DEFAULT_FILTER_TIME_UNIT)
+        params['start_date'] = _parse_date(_get_single_param(_raw_url_params, 'start_date'))
+        params['end_date'] = _parse_date(_get_single_param(_raw_url_params, 'end_date'))
         logging.info(f"Input params: {params=}")
         return params
     return filter_url_params
@@ -217,6 +236,27 @@ def filter_funcs_factory(
         session: Session,
         data_manager: WorkingDataManager,
 ):
+    filter_url_params_calc = filter_url_params_function_factory(input, output, session, data_manager)
+    initialized = reactive.Value(False)
+
+    def _clamp_date_range(transactions, start_date: datetime.date, end_date: datetime.date):
+        min_date, max_date = transactions.date_range()
+        start = max(start_date if start_date is not None else min_date, min_date)
+        end = min(end_date if end_date is not None else max_date, max_date)
+        return start, end, min_date, max_date
+
+    def _dates_for_period(period: str, transactions):
+        today = datetime.date.today()
+        if period == 'Last 30 days':
+            start_date, end_date = today - datetime.timedelta(days=30), today
+        elif period == 'Last 90 days':
+            start_date, end_date = today - datetime.timedelta(days=90), today
+        elif period == 'Last year':
+            start_date, end_date = today - datetime.timedelta(days=365), today
+        else:
+            start_date, end_date = transactions.date_range()
+        return start_date, end_date
+
     @reactive.calc
     def get_filter_params():
         logging.info('Fetching filter params')
@@ -235,45 +275,75 @@ def filter_funcs_factory(
 
     @reactive.calc
     def default_transactions():
-        filter_url_params = filter_url_params_function_factory(input, output, session, data_manager)()
+        filter_url_params = filter_url_params_calc()
         filter_in_tags = filter_url_params['filter_in_tags']
         filter_out_tags = filter_url_params['filter_out_tags']
         transactions = data_manager.get_transactions()
-        filtered_in_transactions = transactions.containing_tags(filter_in_tags)
-        if filtered_in_transactions.size() == 0:
-            error_msg = f"No transactions found for {filter_url_params['time_unit']} time unit containing {filter_url_params['filter_in_tags']} tags."
-            raise ShinyTransactionFilterError(error_msg)
+        filtered_in_transactions = transactions
+        if len(filter_in_tags) > 0:
+            filtered_in_transactions = transactions.containing_tags(filter_in_tags)
+            if filtered_in_transactions.size() == 0:
+                error_msg = f"No transactions found for {filter_url_params['time_unit']} time unit containing {filter_url_params['filter_in_tags']} tags."
+                raise ShinyTransactionFilterError(error_msg)
 
-        filtered_in_and_out_transactions = filtered_in_transactions.not_containing_tags(filter_out_tags,
-                                                                                        empty_tags_strategy='all_true')
-        if filtered_in_and_out_transactions.size() == 0:
-            error_msg = f"No transactions found for {filter_url_params['time_unit']} time unit after filtering out {filter_url_params['filter_in_tags']} tags."
-            raise ShinyTransactionFilterError(error_msg)
+        filtered_in_and_out_transactions = filtered_in_transactions
+        if len(filter_out_tags) > 0:
+            filtered_in_and_out_transactions = filtered_in_transactions.not_containing_tags(
+                filter_out_tags,
+                empty_tags_strategy='all_true')
+            if filtered_in_and_out_transactions.size() == 0:
+                error_msg = f"No transactions found for {filter_url_params['time_unit']} time unit after filtering out {filter_url_params['filter_in_tags']} tags."
+                raise ShinyTransactionFilterError(error_msg)
 
         logging.info(f"URL param transactions: {filtered_in_and_out_transactions.size()=}")
         return filtered_in_and_out_transactions
 
     @reactive.effect
+    @reactive.event(filter_url_params_calc)
     def init():
+        if initialized.get():
+            return
         logging.info('Init')
-        ui.update_select(id='date_period_input_select', selected=DEFAULT_FILTER_PERIOD)# TODO not set correctly, check mecon.app.shiny_app.init for that
-        filter_url_params = filter_url_params_function_factory(input, output, session, data_manager)()
+        filter_url_params = filter_url_params_calc()
         transactions = default_transactions()
+        all_transactions = data_manager.get_transactions()
         all_tags_names = [tag.name for tag in data_manager.all_tags()]
         new_choices = [tag_name for tag_name, cnt in transactions.all_tag_counts().items() if
                        cnt > 0]
 
-        if len(input.filter_in_tags_select()) == 0:
+        current_filter_in = input.filter_in_tags_select() or []
+        if len(current_filter_in) == 0:
             logging.info(f"Updating filter In tags: {len(new_choices)} {filter_url_params['filter_in_tags']}")
             ui.update_selectize(id='filter_in_tags_select',
                                 choices=sorted(new_choices),
                                 selected=filter_url_params['filter_in_tags'])
 
-        if len(input.filter_out_tags_select()) == 0:
+        current_filter_out = input.filter_out_tags_select() or []
+        if len(current_filter_out) == 0:
             logging.info(f"Updating filter OUT tags: {len(all_tags_names)} {filter_url_params['filter_out_tags']}")
             ui.update_selectize(id='filter_out_tags_select',
                                 choices=all_tags_names,
                                 selected=filter_url_params['filter_out_tags'])
+
+        ui.update_radio_buttons(id='time_unit_select', selected=filter_url_params['time_unit'])
+
+        with reactive.isolate():
+            current_period = input.date_period_input_select()
+
+        has_custom_dates = filter_url_params['start_date'] is not None and filter_url_params['end_date'] is not None
+        if has_custom_dates:
+            start_date, end_date = filter_url_params['start_date'], filter_url_params['end_date']
+        else:
+            start_date, end_date = _dates_for_period(current_period, all_transactions)
+
+        start_date, end_date, min_date, max_date = _clamp_date_range(all_transactions, start_date, end_date)
+        ui.update_date_range(id='transactions_date_range',
+                             start=start_date,
+                             end=end_date,
+                             min=min_date,
+                             max=max_date)
+
+        initialized.set(True)
 
         # if len(input.compare_tags_select()) == 0:  TODO
         #     logging.info(f"Updating compare tags: {len(new_choices)} {filter_url_params['compare_tags']}")
@@ -312,31 +382,24 @@ def filter_funcs_factory(
     @reactive.effect
     @reactive.event(input.date_period_input_select)
     def period_change_effect():
+        if not initialized.get():
+            return
         _all_transactions = data_manager.get_transactions()
         logging.info(f"Changed period to '{input.date_period_input_select()}'")
-        if input.date_period_input_select() == 'Last 30 days':
-            start_date, end_date = datetime.date.today() - datetime.timedelta(days=30), datetime.date.today()
-        elif input.date_period_input_select() == 'Last 90 days':
-            start_date, end_date = datetime.date.today() - datetime.timedelta(days=90), datetime.date.today()
-        elif input.date_period_input_select() == 'Last year':
-            start_date, end_date = datetime.date.today() - datetime.timedelta(days=365), datetime.date.today()
-        else:
-            start_date, end_date = _all_transactions.date_range()
-
-        min_date, max_date = _all_transactions.date_range()
+        start_date, end_date = _dates_for_period(input.date_period_input_select(), _all_transactions)
+        start_date, end_date, min_date, max_date = _clamp_date_range(_all_transactions, start_date, end_date)
         logging.info(f"date_range set to {min_date=} and {max_date=}")
-        # if transactions.size()==0:
-        #     ui.update_select(id='date_period_input_select', selected="All")
 
         ui.update_date_range(id='transactions_date_range',
                              start=start_date,
-                             end=min(max_date, end_date),
+                             end=end_date,
                              min=min_date,
                              max=max_date
                              )
 
     @reactive.calc
     def filtered_transactions():
+        reactive.req(initialized.get())
         start_date, end_date, time_unit, filter_in_tags, filter_out_tags = get_filter_params().values()
         transactions = data_manager.get_transactions()
 

--- a/mecon/app/shiny_app.py
+++ b/mecon/app/shiny_app.py
@@ -3,7 +3,7 @@ import logging
 from urllib.parse import urlparse, parse_qs
 
 import pandas as pd
-from shiny import ui, Inputs, Outputs, Session, reactive, render
+from shiny import ui, Inputs, Outputs, Session, reactive, render, req
 
 from mecon import config
 from mecon.app.current_data import WorkingDataManager, WorkingDatasetDir
@@ -399,7 +399,7 @@ def filter_funcs_factory(
 
     @reactive.calc
     def filtered_transactions():
-        reactive.req(initialized.get())
+        req(initialized.get())
         start_date, end_date, time_unit, filter_in_tags, filter_out_tags = get_filter_params().values()
         transactions = data_manager.get_transactions()
 

--- a/mecon/app/shiny_app.py
+++ b/mecon/app/shiny_app.py
@@ -223,6 +223,7 @@ def filter_url_params_function_factory(input: Inputs,
         filter_out_tags_raw = _get_single_param(_raw_url_params, 'filter_out_tags', '')
         params['filter_out_tags'] = filter_out_tags_raw.split(',') if len(filter_out_tags_raw) > 0 else []
         params['time_unit'] = _get_single_param(_raw_url_params, 'time_unit', DEFAULT_FILTER_TIME_UNIT)
+        params['period'] = _get_single_param(_raw_url_params, 'period')
         params['start_date'] = _parse_date(_get_single_param(_raw_url_params, 'start_date'))
         params['end_date'] = _parse_date(_get_single_param(_raw_url_params, 'end_date'))
         logging.info(f"Input params: {params=}")
@@ -238,6 +239,8 @@ def filter_funcs_factory(
 ):
     filter_url_params_calc = filter_url_params_function_factory(input, output, session, data_manager)
     initialized = reactive.Value(False)
+    skip_period_sync = reactive.Value(False)
+    last_period = reactive.Value(None)
 
     def _clamp_date_range(transactions, start_date: datetime.date, end_date: datetime.date):
         min_date, max_date = transactions.date_range()
@@ -330,9 +333,19 @@ def filter_funcs_factory(
         with reactive.isolate():
             current_period = input.date_period_input_select()
 
-        has_custom_dates = filter_url_params['start_date'] is not None and filter_url_params['end_date'] is not None
+        requested_period = filter_url_params.get('period')
+        if requested_period:
+            ui.update_select(id='date_period_input_select', selected=requested_period)
+            current_period = requested_period
+
+        start_date_override = filter_url_params['start_date']
+        end_date_override = filter_url_params['end_date']
+        has_custom_dates = start_date_override is not None or end_date_override is not None
+
         if has_custom_dates:
-            start_date, end_date = filter_url_params['start_date'], filter_url_params['end_date']
+            start_date = start_date_override
+            end_date = end_date_override
+            skip_period_sync.set(True)
         else:
             start_date, end_date = _dates_for_period(current_period, all_transactions)
 
@@ -343,6 +356,7 @@ def filter_funcs_factory(
                              min=min_date,
                              max=max_date)
 
+        last_period.set(current_period)
         initialized.set(True)
 
         # if len(input.compare_tags_select()) == 0:  TODO
@@ -384,9 +398,14 @@ def filter_funcs_factory(
     def period_change_effect():
         if not initialized.get():
             return
+        current_period = input.date_period_input_select()
+        if skip_period_sync.get() and current_period == last_period.get():
+            skip_period_sync.set(False)
+            return
+        skip_period_sync.set(False)
         _all_transactions = data_manager.get_transactions()
-        logging.info(f"Changed period to '{input.date_period_input_select()}'")
-        start_date, end_date = _dates_for_period(input.date_period_input_select(), _all_transactions)
+        logging.info(f"Changed period to '{current_period}'")
+        start_date, end_date = _dates_for_period(current_period, _all_transactions)
         start_date, end_date, min_date, max_date = _clamp_date_range(_all_transactions, start_date, end_date)
         logging.info(f"date_range set to {min_date=} and {max_date=}")
 
@@ -396,11 +415,17 @@ def filter_funcs_factory(
                              min=min_date,
                              max=max_date
                              )
+        last_period.set(current_period)
 
     @reactive.calc
     def filtered_transactions():
         req(initialized.get())
-        start_date, end_date, time_unit, filter_in_tags, filter_out_tags = get_filter_params().values()
+        params = get_filter_params()
+        start_date = params['start_date']
+        end_date = params['end_date']
+        time_unit = params['time_unit']
+        filter_in_tags = params['filter_in_tags']
+        filter_out_tags = params['filter_out_tags']
         transactions = data_manager.get_transactions()
 
         in_date_range_transactions = transactions.select_date_range(start_date, end_date)

--- a/tests/tests_with_datasets/test_shiny_filter_app.py
+++ b/tests/tests_with_datasets/test_shiny_filter_app.py
@@ -61,9 +61,13 @@ def shiny_filter_context(dataset_manager, monkeypatch):
     def update_date_range(*, id, start=None, end=None, **kwargs):
         _set_input_value(id, (start, end))
 
+    def update_select(*, id, selected=None, **kwargs):
+        _set_input_value(id, selected)
+
     monkeypatch.setattr(shiny_module.ui, "update_selectize", update_selectize)
     monkeypatch.setattr(shiny_module.ui, "update_radio_buttons", update_radio_buttons)
     monkeypatch.setattr(shiny_module.ui, "update_date_range", update_date_range)
+    monkeypatch.setattr(shiny_module.ui, "update_select", update_select)
 
     get_filter_params, default_transactions, init_effect, filtered_transactions = shiny_module.filter_funcs_factory(
         session.input,
@@ -95,11 +99,13 @@ def test_url_params_seed_filter_inputs(shiny_filter_context):
         time_unit = ctx.session.input["time_unit_select"]()
         include_tags = ctx.session.input["filter_in_tags_select"]()
         start_date, end_date = ctx.session.input["transactions_date_range"]()
+        period = ctx.session.input["date_period_input_select"]()
 
     assert time_unit == "month"
     assert include_tags == ["Commute"]
     assert start_date == datetime.date(2024, 3, 1)
     assert end_date == datetime.date(2024, 3, 25)
+    assert period == "All"
 
 
 def test_filtered_transactions_respects_tag_filters(shiny_filter_context):
@@ -138,3 +144,26 @@ def test_filtered_transactions_respects_date_range(shiny_filter_context):
     assert len(filtered_df) == 1
     assert all("2024-03-04" in ts for ts in filtered_df["datetime"].astype(str))
     assert all("Commute" in tags for tags in filtered_df["tags"])
+
+
+def test_period_change_resets_date_range(shiny_filter_context):
+    ctx = shiny_filter_context
+
+    with reactive.isolate():
+        ctx.session.input["transactions_date_range"].set(
+            (datetime.date(2024, 3, 4), datetime.date(2024, 3, 4))
+        )
+    _flush_reactive()
+
+    with reactive.isolate():
+        ctx.session.input["date_period_input_select"].set("Last 90 days")
+    _flush_reactive()
+
+    dataset_start, dataset_end = ctx.data_manager.get_transactions().date_range()
+    expected_start = max(dataset_start, datetime.date.today() - datetime.timedelta(days=90))
+    expected_end = min(dataset_end, datetime.date.today())
+
+    with reactive.isolate():
+        start_date, end_date = ctx.session.input["transactions_date_range"]()
+
+    assert (start_date, end_date) == (expected_start, expected_end)

--- a/tests/tests_with_datasets/test_shiny_filter_app.py
+++ b/tests/tests_with_datasets/test_shiny_filter_app.py
@@ -1,0 +1,140 @@
+import asyncio
+import datetime
+from types import SimpleNamespace
+
+import pytest
+from shiny import App, reactive, ui
+from shiny._connection import MockConnection
+
+
+def _flush_reactive():
+    asyncio.run(reactive.flush())
+
+
+def _trigger_initialisation(context: SimpleNamespace):
+    with reactive.isolate():
+        current = context.session.input[".clientdata_url_search"]()
+        context.session.input[".clientdata_url_search"].set(current + "&init=1")
+    _flush_reactive()
+
+
+@pytest.fixture
+def shiny_filter_context(dataset_manager, monkeypatch):
+    from shiny._validation import req as shiny_req
+    from mecon.app import shiny_app as shiny_module
+
+    if not hasattr(reactive, "req"):
+        monkeypatch.setattr(reactive, "req", shiny_req, raising=False)
+    if not hasattr(shiny_module.reactive, "req"):
+        monkeypatch.setattr(shiny_module.reactive, "req", shiny_req, raising=False)
+
+    _dataset, _manager, _root = dataset_manager
+    data_manager = shiny_module.create_data_manager()
+
+    test_app = App(ui.page_fluid(), server=lambda input, output, session: None)
+    session = test_app._create_session(MockConnection())
+
+    transactions = data_manager.get_transactions()
+    dataset_start, dataset_end = transactions.date_range()
+
+    with reactive.isolate():
+        session.input[".clientdata_url_search"] = reactive.Value(
+            "?filter_in_tags=Commute&filter_out_tags=&time_unit=month&start_date=2024-03-01&end_date=2024-03-25"
+        )
+        session.input["transactions_date_range"] = reactive.Value((dataset_start, dataset_end))
+        session.input["date_period_input_select"] = reactive.Value("All")
+        session.input["time_unit_select"] = reactive.Value("month")
+        session.input["filter_in_tags_select"] = reactive.Value([])
+        session.input["filter_out_tags_select"] = reactive.Value([])
+        session.input["compare_tags_select"] = reactive.Value([])
+
+    def _set_input_value(input_id: str, value):
+        with reactive.isolate():
+            session.input[input_id].set(value)
+
+    def update_selectize(*, id, choices=None, selected=None, **kwargs):
+        _set_input_value(id, selected if selected is not None else [])
+
+    def update_radio_buttons(*, id, selected=None, **kwargs):
+        _set_input_value(id, selected)
+
+    def update_date_range(*, id, start=None, end=None, **kwargs):
+        _set_input_value(id, (start, end))
+
+    monkeypatch.setattr(shiny_module.ui, "update_selectize", update_selectize)
+    monkeypatch.setattr(shiny_module.ui, "update_radio_buttons", update_radio_buttons)
+    monkeypatch.setattr(shiny_module.ui, "update_date_range", update_date_range)
+
+    get_filter_params, default_transactions, init_effect, filtered_transactions = shiny_module.filter_funcs_factory(
+        session.input,
+        session.output,
+        session,
+        data_manager,
+    )
+
+    context = SimpleNamespace(
+        app=test_app,
+        session=session,
+        shiny_module=shiny_module,
+        data_manager=data_manager,
+        get_filter_params=get_filter_params,
+        default_transactions=default_transactions,
+        init_effect=init_effect,
+        filtered_transactions=filtered_transactions,
+    )
+
+    _trigger_initialisation(context)
+
+    return context
+
+
+def test_url_params_seed_filter_inputs(shiny_filter_context):
+    ctx = shiny_filter_context
+
+    with reactive.isolate():
+        time_unit = ctx.session.input["time_unit_select"]()
+        include_tags = ctx.session.input["filter_in_tags_select"]()
+        start_date, end_date = ctx.session.input["transactions_date_range"]()
+
+    assert time_unit == "month"
+    assert include_tags == ["Commute"]
+    assert start_date == datetime.date(2024, 3, 1)
+    assert end_date == datetime.date(2024, 3, 25)
+
+
+def test_filtered_transactions_respects_tag_filters(shiny_filter_context):
+    ctx = shiny_filter_context
+
+    with reactive.isolate():
+        trans = ctx.default_transactions()
+    df = trans.dataframe()
+
+    assert len(df) == 2
+    assert all("Commute" in tags for tags in df["tags"])
+
+    with reactive.isolate():
+        ctx.session.input["filter_out_tags_select"].set(["Monzo"])
+    _flush_reactive()
+    with reactive.isolate():
+        filtered = ctx.filtered_transactions()
+    filtered_df = filtered.dataframe()
+
+    assert len(filtered_df) == 1
+    assert all("Monzo" not in tags for tags in filtered_df["tags"])
+
+
+def test_filtered_transactions_respects_date_range(shiny_filter_context):
+    ctx = shiny_filter_context
+
+    with reactive.isolate():
+        ctx.session.input["transactions_date_range"].set(
+            (datetime.date(2024, 3, 4), datetime.date(2024, 3, 4))
+        )
+    _flush_reactive()
+    with reactive.isolate():
+        filtered = ctx.filtered_transactions()
+
+    filtered_df = filtered.dataframe()
+    assert len(filtered_df) == 1
+    assert all("2024-03-04" in ts for ts in filtered_df["datetime"].astype(str))
+    assert all("Commute" in tags for tags in filtered_df["tags"])


### PR DESCRIPTION
## Summary
- reuse cached URL parameter reactives and parse optional date bounds
- gate the filter initialization until URL parameters load and respect provided defaults
- prevent early validation errors while ensuring date range updates clamp to dataset limits

## Testing
- pytest *(fails: missing httpx dependency and required datasets)*

------
https://chatgpt.com/codex/tasks/task_e_68f7dfea9320832699bd4f026c11bc45