### PR TITLE
Improve Shiny filter Playwright test coverage

### DIFF
--- a/docs/scripts/test_standardised_filter_elements_in_shiny/dataset_helper.py
+++ b/docs/scripts/test_standardised_filter_elements_in_shiny/dataset_helper.py
@@ -1,0 +1,247 @@
+"""Helpers for building temporary datasets used in tests or manual checks."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from mecon.etl.account_statements import ACCOUNT_STATEMENT_SOURCE_MAPPING
+
+__all__ = ["create_manual_check_dataset"]
+
+
+_TRANSACTIONS_DATA: list[tuple[str, str, float, str, float, str, str]] = [
+    (
+        "TLHSBC-d20240301t080000-ap300050-ihsbc_001",
+        '2025-10-01 08:00:00',
+        3000.5,
+        "GBP",
+        3000.5,
+        "bank:TLHSBC, Salary payment from Deloitte other_fields:{'transaction_category': 'income', 'transaction_type': 'Credit'}",
+        "All,Friday,HSBC,Money In,Morning,Source TrueLayerHSBC,Weekday,£",
+    ),
+    (
+        "INVENG-d20240301t090000-ap25000-id.0",
+        '2025-10-01 09:00:00',
+        250.0,
+        "GBP",
+        250.0,
+        "bank:INVENG, Monthly deposit from HSBC",
+        "All,Friday,InvestEngine,Money In,Morning,Source INVENG,Weekday,£",
+    ),
+    (
+        "MonzoAPI-d20240302t081500-ap250000-id.tx_0001",
+        '2025-10-02 08:15:00',
+        2500.0,
+        "GBP",
+        2500.0,
+        "bank:MonzoAPI, other_fields: {category: income, description: Monthly salary payment from ITV}",
+        "All,Money In,Monzo,Morning,Saturday,Source MonzoAPI,Weekend,£",
+    ),
+    (
+        "TLHSBC-d20240303t103000-an120000-ihsbc_002",
+        '2025-10-03 10:30:00',
+        -1200.0,
+        "GBP",
+        -1200.0,
+        "bank:TLHSBC, Rent payment to Landlord other_fields:{'transaction_category': 'rent', 'transaction_type': 'Debit'}",
+        "All,HSBC,Money Out,Morning,Source TrueLayerHSBC,Sunday,Weekend,£",
+    ),
+    (
+        "MonzoAPI-d20240304t074500-an320-id.tx_0002",
+        '2025-10-04 07:45:00',
+        -3.2,
+        "GBP",
+        -3.2,
+        "bank:MonzoAPI, other_fields: {category: transport, merchant: TfL, description: TFL Travel - Zone 1 to 3}",
+        "All,Commute,Monday,Money Out,Monzo,Night,Source MonzoAPI,Weekday,£",
+    ),
+    (
+        "MonzoAPI-d20240305t182000-an4520-id.tx_0003",
+        '2025-10-05 18:20:00',
+        -45.2,
+        "GBP",
+        -45.2,
+        "bank:MonzoAPI, other_fields: {category: shopping, merchant: Tesco, description: Tesco Supermarket groceries}",
+        "Afternoon,All,Money Out,Monzo,Source MonzoAPI,Tuesday,Weekday,£",
+    ),
+    (
+        "TLHSBC-d20240306t071500-an4560-ihsbc_003",
+        '2025-10-06 07:15:00',
+        -45.6,
+        "GBP",
+        -45.6,
+        "bank:TLHSBC, TFL Travelcard renewal other_fields:{'transaction_category': 'transport', 'transaction_type': 'Debit'}",
+        "All,Commute,HSBC,Money Out,Night,Source TrueLayerHSBC,Wednesday,Weekday,£",
+    ),
+    (
+        "INVENG-d20240308t153000-an7550-id.1",
+        '2025-10-08 15:30:00',
+        -75.5,
+        "GBP",
+        -75.5,
+        "bank:INVENG, ETF purchase VWRL",
+        "Afternoon,All,Friday,InvestEngine,Money Out,Source INVENG,Weekday,£",
+    ),
+    (
+        "TRD212-d20240311t100500-an15000-i9001",
+        '2025-10-11 10:05:00',
+        -150.0,
+        "GBP",
+        -150.0,
+        "bank:Trading212API,  other_fields:{'action': 'Buy', 'currency_(total)': 'GBP', 'price': 150.0, 'quantity': 1, 'ticker': 'VUSA'}",
+        "All,Monday,Money Out,Morning,Source Trading212API,Trading212,Weekday,£",
+    ),
+    (
+        "INVENG-d20240319t101500-ap1230-id.2",
+        '2025-10-19 10:15:00',
+        12.3,
+        "GBP",
+        12.3,
+        "bank:INVENG, Dividend payout VWRL",
+        "All,InvestEngine,Money In,Morning,Source INVENG,Tuesday,Weekday,£",
+    ),
+    (
+        "TRD212-d20240325t073000-ap525-i9002",
+        '2025-10-25 07:30:00',
+        5.25,
+        "GBP",
+        5.25,
+        "bank:Trading212API,  other_fields:{'action': 'Dividend', 'currency_(total)': 'GBP', 'price': 5.25, 'quantity': 0, 'ticker': 'VUSA'}",
+        "All,Monday,Money In,Night,Source Trading212API,Trading212,Weekday,£",
+    ),
+]
+
+
+def _write_transactions_csv(path: Path, rows: Iterable[tuple[str, int, float, str, float, str, str]]) -> None:
+    df = pd.DataFrame(
+        rows,
+        columns=[
+            "id",
+            "datetime",
+            "amount",
+            "currency",
+            "amount_cur",
+            "description",
+            "tags",
+        ],
+    )
+    today = datetime.datetime.today()
+    df["datetime"] = pd.to_datetime(df["datetime"], unit="ns").dt.strftime("%Y-%m-%d %H:%M:%S")
+    df['datetime'] = df['datetime'].apply(lambda dt: dt.replace('2025-10', f"{today.year}-{today.month}"))
+    df.to_csv(path, index=False)
+
+
+def _write_tags_csv(path: Path) -> None:
+    custom_tags = pd.DataFrame(
+        [
+            {
+                "name": "Commute",
+                "conditions_json": json.dumps([{"description.lower": {"contains": "tfl"}}]),
+                "date_created": "2024-03-01 00:00:00",
+            }
+        ]
+    )
+    custom_tags.to_csv(path, index=False)
+
+
+def _write_empty_tags_metadata(path: Path) -> None:
+    pd.DataFrame(
+        columns=["name", "count", "total_money_in", "total_money_out", "date_modified"]
+    ).to_csv(path, index=False)
+
+
+def _write_settings(path: Path, dataset_name: str) -> None:
+    settings = {
+        "CURRENT_DATASET": dataset_name,
+        "sources": {
+            "HSBC": False,
+            "HSBCSVR": False,
+            "INVENG": True,
+            "Monzo": False,
+            "MonzoAPI": True,
+            "Revolut": False,
+            "Trading212API": True,
+            "TRD212": False,
+            "TRD212_CASH_ISA": False,
+            "TrueLayerHSBC": True,
+            "TrueLayerHSBCSaver": False,
+            "TrueLayerRevolutEUR": False,
+            "TrueLayerRevolutGBP": False,
+            "TrueLayerRevolutHUF": False,
+            "TrueLayerRevolutRON": False,
+        },
+    }
+    path.write_text(json.dumps(settings, indent=4, sort_keys=True))
+
+
+def _write_credentials(path: Path) -> None:
+    credentials = {
+        "truelayer": {
+            "client_id": "dummy",
+            "client_secret": "dummy",
+            "redirect_uri": "https://example.com/callback",
+            "sources": {
+                "ob-hsbc": {
+                    "token": {
+                        "access_token": "token",
+                        "refresh_token": "refresh",
+                        "expires_at": "1970-01-01T00:00:00Z",
+                        "fetched_at": "1970-01-01T00:00:00Z",
+                    }
+                }
+            },
+        },
+        "trading212": {"api_key": "dummy", "mode": "demo"},
+        "monzo-api": {
+            "client_id": "dummy",
+            "client_secret": "dummy",
+            "redirect_url": "https://example.com/callback",
+            "token": {
+                "access_token": "token",
+                "expiry": 0,
+                "refresh_token": "refresh",
+            },
+        },
+    }
+    path.write_text(json.dumps(credentials, indent=4, sort_keys=True))
+
+
+def create_manual_check_dataset(dataset_name: str = "manual_check_dataset") -> Path:
+    """Create a fresh dataset folder backed by temporary storage.
+
+    The dataset contains a transactions CSV with a curated set of transactions and a
+    ``tags.csv`` file with a single custom tag (``Commute``). Built-in tags are
+    automatically provided by :class:`~mecon.data.data_management.CachedFileDataManager`.
+
+    Args:
+        dataset_name: Name of the dataset directory to create inside the temporary root.
+
+    Returns:
+        Path to the dataset directory. The caller is responsible for cleaning up the
+        dataset by removing ``path.parent`` when finished.
+    """
+
+    temp_root = Path(tempfile.mkdtemp(prefix="mecon_manual_dataset_"))
+    dataset_path = temp_root / dataset_name
+    current_dir = dataset_path / "data" / "current"
+    statements_dir = dataset_path / "data" / "statements"
+
+    current_dir.mkdir(parents=True, exist_ok=True)
+    statements_dir.mkdir(parents=True, exist_ok=True)
+
+    for source_dir in ACCOUNT_STATEMENT_SOURCE_MAPPING.keys():
+        (statements_dir / source_dir).mkdir(parents=True, exist_ok=True)
+
+    _write_transactions_csv(current_dir / "transactions.csv", _TRANSACTIONS_DATA)
+    _write_tags_csv(current_dir / "tags.csv")
+    _write_empty_tags_metadata(current_dir / "tags_metadata.csv")
+    _write_settings(dataset_path / "settings.json", dataset_name)
+    _write_credentials(temp_root / "credentials.json")
+
+    return dataset_path

--- a/docs/scripts/test_standardised_filter_elements_in_shiny/simple_filter_app.py
+++ b/docs/scripts/test_standardised_filter_elements_in_shiny/simple_filter_app.py
@@ -1,0 +1,74 @@
+# setup_logging()
+import logging
+
+from shiny import App, Inputs, Outputs, Session, render, ui
+
+from mecon.app import shiny_app
+from mecon.data.data_management import CachedFileDataManager
+from mecon.etl.dataset import Dataset
+
+# from mecon.monitoring.logs import setup_logging
+
+logging.basicConfig()
+logging.getLogger().setLevel(logging.INFO)
+
+DEFAULT_PERIOD = 'Last year'
+DEFAULT_TIME_UNIT = 'month'
+
+app_ui = shiny_app.app_ui_factory(
+    ui.layout_sidebar(
+        ui.sidebar(
+            shiny_app.transactions_intersection_filtered_factory()
+        ),
+        ui.page_fluid(
+            ui.navset_tab(
+                ui.nav_panel(
+                    "Default transactions",
+                    ui.output_data_frame(id="default_transactions_table"),
+                ),
+                ui.nav_panel(
+                    "Filtered transactions",
+                    ui.output_data_frame(id="filtered_transactions_table"),
+                ),
+            )
+        )
+    )
+)
+
+data_manager = CachedFileDataManager(
+    Dataset(r"C:\Users\dimitris\PycharmProjects\mecon\tests\tests_with_datasets\datasets\test_full"))
+
+
+def server(input: Inputs, output: Outputs, session: Session):
+    filter_url_params = shiny_app.filter_url_params_function_factory(
+        input,
+        output,
+        session,
+        data_manager)
+
+    (get_filter_params,
+     default_transactions,
+     init,
+     filtered_transactions) = shiny_app.filter_funcs_factory(
+        input,
+        output,
+        session,
+        data_manager)
+
+    @render.data_frame
+    def default_transactions_table():
+        df = default_transactions().dataframe()
+        logging.info(f"default_transactions_table: {df.shape}")
+        return shiny_app.render_table_standard(df)
+
+    @render.data_frame
+    def filtered_transactions_table():
+        df = filtered_transactions().dataframe()
+        logging.info(f"filtered_transactions_table: {df.shape}")
+        return shiny_app.render_table_standard(df)
+
+
+app = App(app_ui, server)
+
+if __name__ == "__main__":
+    app.run(port=1234, launch_browser=True)

--- a/docs/scripts/test_standardised_filter_elements_in_shiny/simple_filter_app.py
+++ b/docs/scripts/test_standardised_filter_elements_in_shiny/simple_filter_app.py
@@ -23,6 +23,10 @@ app_ui = shiny_app.app_ui_factory(
         ui.page_fluid(
             ui.navset_tab(
                 ui.nav_panel(
+                    "Get filter params",
+                    ui.output_ui(id="get_filter_params_ui"),
+                ),
+                ui.nav_panel(
                     "Default transactions",
                     ui.output_data_frame(id="default_transactions_table"),
                 ),
@@ -40,12 +44,6 @@ data_manager = CachedFileDataManager(
 
 
 def server(input: Inputs, output: Outputs, session: Session):
-    filter_url_params = shiny_app.filter_url_params_function_factory(
-        input,
-        output,
-        session,
-        data_manager)
-
     (get_filter_params,
      default_transactions,
      init,
@@ -54,6 +52,10 @@ def server(input: Inputs, output: Outputs, session: Session):
         output,
         session,
         data_manager)
+
+    @render.ui
+    def get_filter_params_ui():
+        return ui.HTML(get_filter_params())
 
     @render.data_frame
     def default_transactions_table():

--- a/docs/scripts/test_standardised_filter_elements_in_shiny/simple_filter_app.py
+++ b/docs/scripts/test_standardised_filter_elements_in_shiny/simple_filter_app.py
@@ -24,7 +24,7 @@ app_ui = shiny_app.app_ui_factory(
             ui.navset_tab(
                 ui.nav_panel(
                     "Get filter params",
-                    ui.output_ui(id="get_filter_params_ui"),
+                    ui.output_ui(id="get_filter_params_text"),
                 ),
                 ui.nav_panel(
                     "Default transactions",
@@ -53,9 +53,9 @@ def server(input: Inputs, output: Outputs, session: Session):
         session,
         data_manager)
 
-    @render.ui
-    def get_filter_params_ui():
-        return ui.HTML(get_filter_params())
+    @render.text
+    def get_filter_params_text():
+        return get_filter_params()
 
     @render.data_frame
     def default_transactions_table():

--- a/docs/scripts/test_standardised_filter_elements_in_shiny/simple_filter_app.py
+++ b/docs/scripts/test_standardised_filter_elements_in_shiny/simple_filter_app.py
@@ -24,7 +24,7 @@ app_ui = shiny_app.app_ui_factory(
             ui.navset_tab(
                 ui.nav_panel(
                     "Get filter params",
-                    ui.output_ui(id="get_filter_params_text"),
+                    ui.output_text(id="get_filter_params_text"),
                 ),
                 ui.nav_panel(
                     "Default transactions",
@@ -39,8 +39,11 @@ app_ui = shiny_app.app_ui_factory(
     )
 )
 
+from dataset_helper import create_manual_check_dataset
+dataset_path = create_manual_check_dataset()
+logging.info(f"{dataset_path=}")
 data_manager = CachedFileDataManager(
-    Dataset(r"C:\Users\dimitris\PycharmProjects\mecon\tests\tests_with_datasets\datasets\test_full"))
+    Dataset(dataset_path))
 
 
 def server(input: Inputs, output: Outputs, session: Session):
@@ -61,13 +64,13 @@ def server(input: Inputs, output: Outputs, session: Session):
     def default_transactions_table():
         df = default_transactions().dataframe()
         logging.info(f"default_transactions_table: {df.shape}")
-        return shiny_app.render_table_standard(df)
+        return df
 
     @render.data_frame
     def filtered_transactions_table():
         df = filtered_transactions().dataframe()
         logging.info(f"filtered_transactions_table: {df.shape}")
-        return shiny_app.render_table_standard(df)
+        return df
 
 
 app = App(app_ui, server)

--- a/docs/scripts/test_standardised_filter_elements_in_shiny/tests/Makefile
+++ b/docs/scripts/test_standardised_filter_elements_in_shiny/tests/Makefile
@@ -1,0 +1,4 @@
+
+install:
+	pip install pytest-playwright
+	playwright install

--- a/docs/scripts/test_standardised_filter_elements_in_shiny/tests/test_app.py
+++ b/docs/scripts/test_standardised_filter_elements_in_shiny/tests/test_app.py
@@ -1,0 +1,28 @@
+from playwright.sync_api import Page
+from shiny.playwright import controller
+from shiny.pytest import create_app_fixture
+from shiny.run import ShinyAppProc
+
+from mecon.data.data_management import CachedFileDataManager
+from mecon.etl.dataset import Dataset
+
+dataset = Dataset(r"C:\Users\dimitris\PycharmProjects\mecon\tests\tests_with_datasets\datasets\test_full")
+data_manager = CachedFileDataManager(dataset)
+
+
+app = create_app_fixture("..\simple_filter_app.py")
+
+
+# pip install pytest-playwright
+# playwright install
+def test_app(page: Page, app: ShinyAppProc):
+
+    page.goto(app.url)
+    # Add test code here
+    filter_params = controller.OutputText(page, 'get_filter_params_text')
+    filter_params.expect_value("{'start_date': None, 'end_date': datetime.date(2024, 3, 25), 'time_unit': 'month', 'filter_in_tags': (), 'filter_out_tags': ()}")
+
+    expected_default_transactions_df = data_manager.get_transactions().dataframe()
+    default_transactions_df = controller.OutputDataFrame(page, 'default_transactions_table')
+    default_transactions_df.expect_ncol(expected_default_transactions_df.shape[1])
+    default_transactions_df.expect_nrow(expected_default_transactions_df.shape[0])

--- a/docs/scripts/test_standardised_filter_elements_in_shiny/tests/test_app.py
+++ b/docs/scripts/test_standardised_filter_elements_in_shiny/tests/test_app.py
@@ -1,3 +1,11 @@
+from __future__ import annotations
+
+import datetime
+import shutil
+import sys
+from pathlib import Path
+from typing import Iterable
+
 from playwright.sync_api import Page
 from shiny.playwright import controller
 from shiny.pytest import create_app_fixture
@@ -6,23 +14,106 @@ from shiny.run import ShinyAppProc
 from mecon.data.data_management import CachedFileDataManager
 from mecon.etl.dataset import Dataset
 
-dataset = Dataset(r"C:\Users\dimitris\PycharmProjects\mecon\tests\tests_with_datasets\datasets\test_full")
-data_manager = CachedFileDataManager(dataset)
+
+TESTS_DIR = Path(__file__).resolve().parent
+APP_DIR = TESTS_DIR.parent
+
+if str(APP_DIR) not in sys.path:
+    sys.path.insert(0, str(APP_DIR))
+
+import dataset_helper  # noqa: E402  (import after sys.path mutation)
 
 
-app = create_app_fixture("..\simple_filter_app.py")
+APP_PATH = APP_DIR / "simple_filter_app.py"
 
 
-# pip install pytest-playwright
-# playwright install
+app = create_app_fixture(str(APP_PATH))
+
+
+def _normalize_tags(raw: Iterable[str] | str | None) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        return (raw,)
+    return tuple(raw)
+
+
+def _create_data_manager() -> tuple[CachedFileDataManager, Path]:
+    dataset_path = dataset_helper.create_manual_check_dataset()
+    return CachedFileDataManager(Dataset(dataset_path)), dataset_path
+
+
+def _expected_filtered_transactions(
+    data_manager: CachedFileDataManager,
+    *,
+    start_date: datetime.date | None,
+    end_date: datetime.date | None,
+    filter_in_tags: tuple[str, ...],
+    filter_out_tags: tuple[str, ...],
+    time_unit: str,
+):
+    transactions = data_manager.get_transactions()
+    in_date_range = transactions.select_date_range(start_date, end_date)
+    filtered_in = in_date_range.containing_tags(filter_in_tags)
+    filtered_out = filtered_in.not_containing_tags(
+        filter_out_tags, empty_tags_strategy="all_true"
+    )
+    return filtered_out.group_and_fill_transactions(
+        grouping_key=time_unit,
+        aggregation_key="sum",
+    )
+
+
 def test_app(page: Page, app: ShinyAppProc):
-
     page.goto(app.url)
-    # Add test code here
-    filter_params = controller.OutputText(page, 'get_filter_params_text')
-    filter_params.expect_value("{'start_date': None, 'end_date': datetime.date(2024, 3, 25), 'time_unit': 'month', 'filter_in_tags': (), 'filter_out_tags': ()}")
 
-    expected_default_transactions_df = data_manager.get_transactions().dataframe()
-    default_transactions_df = controller.OutputDataFrame(page, 'default_transactions_table')
-    default_transactions_df.expect_ncol(expected_default_transactions_df.shape[1])
-    default_transactions_df.expect_nrow(expected_default_transactions_df.shape[0])
+    filter_params_output = controller.OutputText(page, "get_filter_params_text")
+    filter_params_text = filter_params_output.get_value()
+    filter_params = eval(filter_params_text, {"datetime": datetime}, {})
+
+    filter_in_tags = _normalize_tags(filter_params.get("filter_in_tags"))
+    filter_out_tags = _normalize_tags(filter_params.get("filter_out_tags"))
+
+    assert filter_params["time_unit"] == "day"
+    assert filter_in_tags == ()
+    assert filter_out_tags == ()
+
+    data_manager, dataset_path = _create_data_manager()
+    try:
+        transactions = data_manager.get_transactions()
+        expected_default_df = transactions.dataframe()
+
+        default_table = controller.OutputDataFrame(page, "default_transactions_table")
+        default_table.expect_ncol(expected_default_df.shape[1])
+        default_table.expect_nrow(expected_default_df.shape[0])
+        default_table.expect_column_labels(expected_default_df.columns.tolist())
+
+        if not expected_default_df.empty:
+            id_col_index = expected_default_df.columns.get_loc("id")
+            default_table.expect_cell_value(
+                str(expected_default_df.iloc[0, id_col_index]), row=0, col=id_col_index
+            )
+
+        filtered_transactions = _expected_filtered_transactions(
+            data_manager,
+            start_date=filter_params.get("start_date"),
+            end_date=filter_params.get("end_date"),
+            filter_in_tags=filter_in_tags,
+            filter_out_tags=filter_out_tags,
+            time_unit=filter_params.get("time_unit"),
+        )
+        expected_filtered_df = filtered_transactions.dataframe()
+
+        filtered_table = controller.OutputDataFrame(page, "filtered_transactions_table")
+        filtered_table.expect_ncol(expected_filtered_df.shape[1])
+        filtered_table.expect_nrow(expected_filtered_df.shape[0])
+        filtered_table.expect_column_labels(expected_filtered_df.columns.tolist())
+
+        if not expected_filtered_df.empty:
+            id_col_index = expected_filtered_df.columns.get_loc("id")
+            filtered_table.expect_cell_value(
+                str(expected_filtered_df.iloc[0, id_col_index]), row=0, col=id_col_index
+            )
+    finally:
+        shutil.rmtree(dataset_path.parent, ignore_errors=True)
+

--- a/mecon/app/shiny_app.py
+++ b/mecon/app/shiny_app.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 from urllib.parse import urlparse, parse_qs
 
+import dateparser
 import pandas as pd
 from shiny import ui, Inputs, Outputs, Session, reactive, render, req
 
@@ -113,14 +114,14 @@ def transactions_intersection_filtered_factory(
         ui.input_select(
             id='date_period_input_select',
             label='Select date period',
-            choices=['Last 30 days', 'Last 90 days', 'Last year', 'All'], # TODO last week, q1-4 (if exist), <2020, 2020, 2021, 2022, etc...
+            choices=['Last 7 days', 'Last 30 days', 'Last 90 days', 'Last year', 'All'], # TODO last week, q1-4 (if exist), <2020, 2020, 2021, 2022, etc...
             selected=selected_period
         ),
         ui.input_date_range(
             id='transactions_date_range',
             label='Select date range',
-            start=datetime.date.today() - datetime.timedelta(days=365),
-            end=datetime.date.today(),
+            start=dateparser.parse('today'), #datetime.date.today() - datetime.timedelta(days=365),
+            end=dateparser.parse('today'),#datetime.date.today(),
             format='dd-mm-yyyy',
             separator=':'
         ),
@@ -242,15 +243,23 @@ def filter_funcs_factory(
     skip_period_sync = reactive.Value(False)
     last_period = reactive.Value(None)
 
-    def _clamp_date_range(transactions, start_date: datetime.date, end_date: datetime.date):
-        min_date, max_date = transactions.date_range()
-        start = max(start_date if start_date is not None else min_date, min_date)
-        end = min(end_date if end_date is not None else max_date, max_date)
-        return start, end, min_date, max_date
+    def _clamp_date_range(transactions, requested_start_date: datetime.date, requested_end_date: datetime.date):
+        """
+        make sure that the start_date and end_date are valid for the transactions.date_range
+        """
+        tx_min_date, tx_max_date = transactions.date_range()
+        if tx_max_date < requested_start_date:
+            return None
+
+        start = max(requested_start_date if requested_start_date is not None else tx_min_date, tx_min_date)
+        end = min(requested_end_date if requested_end_date is not None else tx_max_date, tx_max_date)
+        return start, end, tx_min_date, tx_max_date
 
     def _dates_for_period(period: str, transactions):
         today = datetime.date.today()
-        if period == 'Last 30 days':
+        if period == 'Last 7 days':
+            start_date, end_date = today - datetime.timedelta(days=7), today
+        elif period == 'Last 30 days':
             start_date, end_date = today - datetime.timedelta(days=30), today
         elif period == 'Last 90 days':
             start_date, end_date = today - datetime.timedelta(days=90), today
@@ -349,12 +358,12 @@ def filter_funcs_factory(
         else:
             start_date, end_date = _dates_for_period(current_period, all_transactions)
 
-        start_date, end_date, min_date, max_date = _clamp_date_range(all_transactions, start_date, end_date)
-        ui.update_date_range(id='transactions_date_range',
-                             start=start_date,
-                             end=end_date,
-                             min=min_date,
-                             max=max_date)
+        # start_date, end_date, min_date, max_date = _clamp_date_range(all_transactions, start_date, end_date)
+        # ui.update_date_range(id='transactions_date_range',
+        #                      start=start_date,
+        #                      end=end_date,
+        #                      min=min_date,
+        #                      max=max_date)
 
         last_period.set(current_period)
         initialized.set(True)
@@ -406,7 +415,11 @@ def filter_funcs_factory(
         _all_transactions = data_manager.get_transactions()
         logging.info(f"Changed period to '{current_period}'")
         start_date, end_date = _dates_for_period(current_period, _all_transactions)
-        start_date, end_date, min_date, max_date = _clamp_date_range(_all_transactions, start_date, end_date)
+        date_range_values = _clamp_date_range(_all_transactions, start_date, end_date)
+        if date_range_values:
+            start_date, end_date, min_date, max_date = date_range_values
+        else:
+            start_date, end_date, min_date, max_date = [end_date]*4
         logging.info(f"date_range set to {min_date=} and {max_date=}")
 
         ui.update_date_range(id='transactions_date_range',

--- a/mecon/app/shiny_app.py
+++ b/mecon/app/shiny_app.py
@@ -197,15 +197,34 @@ def filter_url_params_function_factory(input: Inputs,
                                 session: Session,
                                 data_manager: WorkingDataManager, ):
 
+    url_params = url_params_function_factory(input, output, session, data_manager)
+
+    def _get_single_param(params: dict, key: str, default=None):
+        values = params.get(key)
+        if not values:
+            return default
+        return values[0]
+
+    def _parse_date(value: str | None):
+        if value is None or len(value) == 0:
+            return None
+        try:
+            return datetime.date.fromisoformat(value)
+        except ValueError:
+            logging.warning(f"Invalid date provided for '{value}', ignoring")
+            return None
+
     @reactive.calc
     def filter_url_params():
-        _url_params = url_params_function_factory(input, output, session, data_manager)()
+        _raw_url_params = url_params()
         params = {}
-        params['filter_in_tags'] = _url_params.get('filter_in_tags', [''])[0]
-        params['filter_in_tags'] = params['filter_in_tags'].split(',') if len(params['filter_in_tags']) > 0 else []
-        params['filter_out_tags'] = _url_params.get('filter_out_tags', [''])[0]
-        params['filter_out_tags'] = params['filter_out_tags'].split(',') if len(params['filter_out_tags']) > 0 else []
-        params['time_unit'] = _url_params.get('time_unit', DEFAULT_FILTER_TIME_UNIT)
+        filter_in_tags_raw = _get_single_param(_raw_url_params, 'filter_in_tags', '')
+        params['filter_in_tags'] = filter_in_tags_raw.split(',') if len(filter_in_tags_raw) > 0 else []
+        filter_out_tags_raw = _get_single_param(_raw_url_params, 'filter_out_tags', '')
+        params['filter_out_tags'] = filter_out_tags_raw.split(',') if len(filter_out_tags_raw) > 0 else []
+        params['time_unit'] = _get_single_param(_raw_url_params, 'time_unit', DEFAULT_FILTER_TIME_UNIT)
+        params['start_date'] = _parse_date(_get_single_param(_raw_url_params, 'start_date'))
+        params['end_date'] = _parse_date(_get_single_param(_raw_url_params, 'end_date'))
         logging.info(f"Input params: {params=}")
         return params
     return filter_url_params
@@ -217,6 +236,27 @@ def filter_funcs_factory(
         session: Session,
         data_manager: WorkingDataManager,
 ):
+    filter_url_params_calc = filter_url_params_function_factory(input, output, session, data_manager)
+    initialized = reactive.Value(False)
+
+    def _clamp_date_range(transactions, start_date: datetime.date, end_date: datetime.date):
+        min_date, max_date = transactions.date_range()
+        start = max(start_date if start_date is not None else min_date, min_date)
+        end = min(end_date if end_date is not None else max_date, max_date)
+        return start, end, min_date, max_date
+
+    def _dates_for_period(period: str, transactions):
+        today = datetime.date.today()
+        if period == 'Last 30 days':
+            start_date, end_date = today - datetime.timedelta(days=30), today
+        elif period == 'Last 90 days':
+            start_date, end_date = today - datetime.timedelta(days=90), today
+        elif period == 'Last year':
+            start_date, end_date = today - datetime.timedelta(days=365), today
+        else:
+            start_date, end_date = transactions.date_range()
+        return start_date, end_date
+
     @reactive.calc
     def get_filter_params():
         logging.info('Fetching filter params')
@@ -235,45 +275,75 @@ def filter_funcs_factory(
 
     @reactive.calc
     def default_transactions():
-        filter_url_params = filter_url_params_function_factory(input, output, session, data_manager)()
+        filter_url_params = filter_url_params_calc()
         filter_in_tags = filter_url_params['filter_in_tags']
         filter_out_tags = filter_url_params['filter_out_tags']
         transactions = data_manager.get_transactions()
-        filtered_in_transactions = transactions.containing_tags(filter_in_tags)
-        if filtered_in_transactions.size() == 0:
-            error_msg = f"No transactions found for {filter_url_params['time_unit']} time unit containing {filter_url_params['filter_in_tags']} tags."
-            raise ShinyTransactionFilterError(error_msg)
+        filtered_in_transactions = transactions
+        if len(filter_in_tags) > 0:
+            filtered_in_transactions = transactions.containing_tags(filter_in_tags)
+            if filtered_in_transactions.size() == 0:
+                error_msg = f"No transactions found for {filter_url_params['time_unit']} time unit containing {filter_url_params['filter_in_tags']} tags."
+                raise ShinyTransactionFilterError(error_msg)
 
-        filtered_in_and_out_transactions = filtered_in_transactions.not_containing_tags(filter_out_tags,
-                                                                                        empty_tags_strategy='all_true')
-        if filtered_in_and_out_transactions.size() == 0:
-            error_msg = f"No transactions found for {filter_url_params['time_unit']} time unit after filtering out {filter_url_params['filter_in_tags']} tags."
-            raise ShinyTransactionFilterError(error_msg)
+        filtered_in_and_out_transactions = filtered_in_transactions
+        if len(filter_out_tags) > 0:
+            filtered_in_and_out_transactions = filtered_in_transactions.not_containing_tags(
+                filter_out_tags,
+                empty_tags_strategy='all_true')
+            if filtered_in_and_out_transactions.size() == 0:
+                error_msg = f"No transactions found for {filter_url_params['time_unit']} time unit after filtering out {filter_url_params['filter_in_tags']} tags."
+                raise ShinyTransactionFilterError(error_msg)
 
         logging.info(f"URL param transactions: {filtered_in_and_out_transactions.size()=}")
         return filtered_in_and_out_transactions
 
     @reactive.effect
+    @reactive.event(filter_url_params_calc)
     def init():
+        if initialized.get():
+            return
         logging.info('Init')
-        ui.update_select(id='date_period_input_select', selected=DEFAULT_FILTER_PERIOD)# TODO not set correctly, check mecon.app.shiny_app.init for that
-        filter_url_params = filter_url_params_function_factory(input, output, session, data_manager)()
+        filter_url_params = filter_url_params_calc()
         transactions = default_transactions()
+        all_transactions = data_manager.get_transactions()
         all_tags_names = [tag.name for tag in data_manager.all_tags()]
         new_choices = [tag_name for tag_name, cnt in transactions.all_tag_counts().items() if
                        cnt > 0]
 
-        if len(input.filter_in_tags_select()) == 0:
+        current_filter_in = input.filter_in_tags_select() or []
+        if len(current_filter_in) == 0:
             logging.info(f"Updating filter In tags: {len(new_choices)} {filter_url_params['filter_in_tags']}")
             ui.update_selectize(id='filter_in_tags_select',
                                 choices=sorted(new_choices),
                                 selected=filter_url_params['filter_in_tags'])
 
-        if len(input.filter_out_tags_select()) == 0:
+        current_filter_out = input.filter_out_tags_select() or []
+        if len(current_filter_out) == 0:
             logging.info(f"Updating filter OUT tags: {len(all_tags_names)} {filter_url_params['filter_out_tags']}")
             ui.update_selectize(id='filter_out_tags_select',
                                 choices=all_tags_names,
                                 selected=filter_url_params['filter_out_tags'])
+
+        ui.update_radio_buttons(id='time_unit_select', selected=filter_url_params['time_unit'])
+
+        with reactive.isolate():
+            current_period = input.date_period_input_select()
+
+        has_custom_dates = filter_url_params['start_date'] is not None and filter_url_params['end_date'] is not None
+        if has_custom_dates:
+            start_date, end_date = filter_url_params['start_date'], filter_url_params['end_date']
+        else:
+            start_date, end_date = _dates_for_period(current_period, all_transactions)
+
+        start_date, end_date, min_date, max_date = _clamp_date_range(all_transactions, start_date, end_date)
+        ui.update_date_range(id='transactions_date_range',
+                             start=start_date,
+                             end=end_date,
+                             min=min_date,
+                             max=max_date)
+
+        initialized.set(True)
 
         # if len(input.compare_tags_select()) == 0:  TODO
         #     logging.info(f"Updating compare tags: {len(new_choices)} {filter_url_params['compare_tags']}")
@@ -312,31 +382,24 @@ def filter_funcs_factory(
     @reactive.effect
     @reactive.event(input.date_period_input_select)
     def period_change_effect():
+        if not initialized.get():
+            return
         _all_transactions = data_manager.get_transactions()
         logging.info(f"Changed period to '{input.date_period_input_select()}'")
-        if input.date_period_input_select() == 'Last 30 days':
-            start_date, end_date = datetime.date.today() - datetime.timedelta(days=30), datetime.date.today()
-        elif input.date_period_input_select() == 'Last 90 days':
-            start_date, end_date = datetime.date.today() - datetime.timedelta(days=90), datetime.date.today()
-        elif input.date_period_input_select() == 'Last year':
-            start_date, end_date = datetime.date.today() - datetime.timedelta(days=365), datetime.date.today()
-        else:
-            start_date, end_date = _all_transactions.date_range()
-
-        min_date, max_date = _all_transactions.date_range()
+        start_date, end_date = _dates_for_period(input.date_period_input_select(), _all_transactions)
+        start_date, end_date, min_date, max_date = _clamp_date_range(_all_transactions, start_date, end_date)
         logging.info(f"date_range set to {min_date=} and {max_date=}")
-        # if transactions.size()==0:
-        #     ui.update_select(id='date_period_input_select', selected="All")
 
         ui.update_date_range(id='transactions_date_range',
                              start=start_date,
-                             end=min(max_date, end_date),
+                             end=end_date,
                              min=min_date,
                              max=max_date
                              )
 
     @reactive.calc
     def filtered_transactions():
+        reactive.req(initialized.get())
         start_date, end_date, time_unit, filter_in_tags, filter_out_tags = get_filter_params().values()
         transactions = data_manager.get_transactions()
 

--- a/mecon/app/shiny_app.py
+++ b/mecon/app/shiny_app.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from enum import Enum
 from urllib.parse import urlparse, parse_qs
 
 import dateparser
@@ -53,9 +54,11 @@ def url_for_tag_report(**kwargs):
     url = build_url("http://127.0.0.1:8001/reports/tags/", kwargs)
     return url
 
+
 def url_for_comparison_report(**kwargs):
     url = build_url("http://127.0.0.1:8001/reports/compare/", kwargs)
     return url
+
 
 def url_for_tag_edit(**kwargs):
     url = build_url("http://127.0.0.1:8002/edit_data/tags/edit/", kwargs)
@@ -68,8 +71,10 @@ def url_for_tag_edit(**kwargs):
 # all_transactions = dm.get_transactions()
 
 tab_title = ui.tags.title("μEcon App")
-page_title = ui.HTML(f"<big><big><big>mEcon</big></big></big><sub><small><u><i>v{config.MECON_VERSION}</i></u></small></sub><br>")
-dataset_label = ui.tooltip(ui.HTML(f"<sub><small>Selected dataset: {get_working_dataset().name}</small></sub>"), f"Dataset directory: {config.DEFAULT_DATASETS_DIR_PATH}")
+page_title = ui.HTML(
+    f"<big><big><big>mEcon</big></big></big><sub><small><u><i>v{config.MECON_VERSION}</i></u></small></sub><br>")
+dataset_label = ui.tooltip(ui.HTML(f"<sub><small>Selected dataset: {get_working_dataset().name}</small></sub>"),
+                           f"Dataset directory: {config.DEFAULT_DATASETS_DIR_PATH}")
 navbar = ui.navset_pill(
     ui.nav_control(ui.tags.a("Main page", href=f"http://127.0.0.1:8000/")),
     ui.nav_control(ui.tags.a("Datasets", href=f"http://127.0.0.1:8000/datasets")),
@@ -98,6 +103,95 @@ DEFAULT_FILTER_PERIOD = config.SHINY_DEFAULT_FILTER_PERIOD
 DEFAULT_FILTER_TIME_UNIT = config.SHINY_DEFAULT_FILTER_TIME_UNIT
 
 
+class DatePeriod:
+    _relative_period_names = ['Today',
+                              'Current week',
+                              'Last 7 days',
+                              'Previous week',
+                              'This month',
+                              'Last 30 days',
+                              'Last 3 months',
+                              f"YtD ({datetime.date.today().year})",
+                              'All']
+
+    @staticmethod
+    def _quarter_names():
+        today = datetime.date.today()
+        quarters = [f"Q{q_n}" for q_n in range(1, 2 + (today.month - 1) // 3)]
+        return quarters
+
+    @staticmethod
+    def _past_year_names():
+        today = datetime.date.today()
+        years = ['<2020'] + [f"{y}" for y in range(2020, today.year)]
+        return years
+
+    @staticmethod
+    def date_periods_key_values():
+        all_periods = DatePeriod._relative_period_names + DatePeriod._quarter_names() + DatePeriod._past_year_names()
+        return {i: i for i in all_periods}
+
+    @staticmethod
+    def date_periods_categorised():
+        return {
+            'Relative': {p: p for p in DatePeriod._relative_period_names},
+            'Years': {y: y for y in DatePeriod._past_year_names()},
+            'Quarters': {q: q for q in DatePeriod._quarter_names()}
+        }
+
+    @staticmethod
+    def date_range_for_period(period: str,
+                              min_date: datetime.datetime = None,
+                              max_date: datetime.datetime = None):
+        today = datetime.date.today()
+        if period in 'Today':
+            start_date, end_date = today, today
+        elif period == 'Current week':
+            start_date, end_date = dateparser.parse('Monday').date(), today
+        elif period == 'Last 7 days':
+            start_date, end_date = dateparser.parse('a week ago').date(), today
+        elif period == 'Previous week':
+            sunday = dateparser.parse('Sunday').date()
+            start_date, end_date = sunday - datetime.timedelta(days=6), sunday
+        elif period == 'This month':
+            start_date, end_date = today - datetime.timedelta(days=today.day - 1), today
+        elif period == 'Last 30 days':
+            start_date, end_date = today - datetime.timedelta(days=30), today
+        elif period == 'Last 3 months':
+            start_date, end_date = today - datetime.timedelta(days=90), today
+        elif period == 'Last 30 days':
+            start_date, end_date = today - datetime.timedelta(days=30), today
+        elif period.startswith('YtD (20'):
+            start_date, end_date = datetime.date(year=today.year, month=1, day=1), today
+        elif period == 'Last year':
+            start_date, end_date = datetime.date(year=2019, month=1, day=1), today
+        elif period.startswith('Q1'):
+            start_date, end_date = datetime.date(year=today.year, month=1, day=1), \
+                min(datetime.date(year=today.year, month=3, day=1), today)
+        elif period.startswith('Q2'):
+            start_date, end_date = datetime.date(year=today.year, month=3, day=1), \
+                min(datetime.date(year=today.year, month=6, day=1), today)
+        elif period.startswith('Q3'):
+            start_date, end_date = datetime.date(year=today.year, month=6, day=1), \
+                min(datetime.date(year=today.year, month=9, day=1), today)
+        elif period.startswith('Q4'):
+            start_date, end_date = datetime.date(year=today.year, month=9, day=1), \
+                min(datetime.date(year=today.year, month=12, day=1), today)
+        elif period.startswith('<2020'):
+            start_date, end_date = min_date if min_date else datetime.date(year=2019, month=1, day=1), \
+                        datetime.date(year=2019, month=12, day=31)
+        elif period.startswith('202') and period.isnumeric():
+            int_year = int(period)
+            start_date, end_date = datetime.date(year=int_year, month=1, day=1), \
+                        datetime.date(year=int_year, month=12, day=31)
+        else:
+            start_date, end_date = min_date, max_date
+        return start_date, end_date
+
+
+# t ={v:DatePeriod.date_range_for_period(v) for v in DatePeriod.date_periods_key_values().values()}
+
+
 def transactions_intersection_filtered_factory(
         default_period=None,
         fixed_time_unit=False,
@@ -114,14 +208,16 @@ def transactions_intersection_filtered_factory(
         ui.input_select(
             id='date_period_input_select',
             label='Select date period',
-            choices=['Last 7 days', 'Last 30 days', 'Last 90 days', 'Last year', 'All'], # TODO last week, q1-4 (if exist), <2020, 2020, 2021, 2022, etc...
+            # choices=['Last 7 days', 'Last 30 days', 'Last 90 days', 'Last year', 'All'],
+            choices=DatePeriod.date_periods_categorised(),
+            # TODO last week, q1-4 (if exist), <2020, 2020, 2021, 2022, etc...
             selected=selected_period
         ),
         ui.input_date_range(
             id='transactions_date_range',
             label='Select date range',
-            start=dateparser.parse('today'), #datetime.date.today() - datetime.timedelta(days=365),
-            end=dateparser.parse('today'),#datetime.date.today(),
+            start=dateparser.parse('today'),  # datetime.date.today() - datetime.timedelta(days=365),
+            end=dateparser.parse('today'),  # datetime.date.today(),
             format='dd-mm-yyyy',
             separator=':'
         ),
@@ -165,8 +261,8 @@ class ShinyTransactionFilterError(ValueError):
         super().__init__(message)
 
 
-def _parse_params(input_url:str,
-                  ensure_exists:str|list[str]|None=None):
+def _parse_params(input_url: str,
+                  ensure_exists: str | list[str] | None = None):
     urlparse_result = urlparse(input_url)
     _url_params = parse_qs(urlparse_result.query)
 
@@ -184,20 +280,21 @@ def url_params_function_factory(input: Inputs,
                                 session: Session,
                                 data_manager: WorkingDataManager,
                                 ensure_exists=None):
-
     @reactive.calc
     def get_url_params() -> dict:
         logging.info(f"{input['.clientdata_url_search'].get()=}")
-        _url_params = _parse_params(input['.clientdata_url_search'].get(), ensure_exists=ensure_exists)  # TODO move to a reactive.calc func
+        _url_params = _parse_params(input['.clientdata_url_search'].get(),
+                                    ensure_exists=ensure_exists)  # TODO move to a reactive.calc func
         logging.info(f"Input params: {_url_params=}")
         return _url_params
+
     return get_url_params
 
-def filter_url_params_function_factory(input: Inputs,
-                                output: Outputs,
-                                session: Session,
-                                data_manager: WorkingDataManager, ):
 
+def filter_url_params_function_factory(input: Inputs,
+                                       output: Outputs,
+                                       session: Session,
+                                       data_manager: WorkingDataManager, ):
     url_params = url_params_function_factory(input, output, session, data_manager)
 
     def _get_single_param(params: dict, key: str, default=None):
@@ -229,6 +326,7 @@ def filter_url_params_function_factory(input: Inputs,
         params['end_date'] = _parse_date(_get_single_param(_raw_url_params, 'end_date'))
         logging.info(f"Input params: {params=}")
         return params
+
     return filter_url_params
 
 
@@ -244,29 +342,33 @@ def filter_funcs_factory(
     last_period = reactive.Value(None)
 
     def _clamp_date_range(transactions, requested_start_date: datetime.date, requested_end_date: datetime.date):
-        """
-        make sure that the start_date and end_date are valid for the transactions.date_range
-        """
-        tx_min_date, tx_max_date = transactions.date_range()
-        if tx_max_date < requested_start_date:
-            return None
-
-        start = max(requested_start_date if requested_start_date is not None else tx_min_date, tx_min_date)
-        end = min(requested_end_date if requested_end_date is not None else tx_max_date, tx_max_date)
-        return start, end, tx_min_date, tx_max_date
+        # """
+        # make sure that the start_date and end_date are valid for the transactions.date_range
+        # """
+        # tx_min_date, tx_max_date = transactions.date_range()
+        # if tx_max_date < requested_start_date:
+        #     return None
+        #
+        # start = max(requested_start_date if requested_start_date is not None else tx_min_date, tx_min_date)
+        # end = min(requested_end_date if requested_end_date is not None else tx_max_date, tx_max_date)
+        # return start, end, tx_min_date, tx_max_date
+        return  requested_start_date, requested_end_date, requested_start_date, requested_end_date
 
     def _dates_for_period(period: str, transactions):
-        today = datetime.date.today()
-        if period == 'Last 7 days':
-            start_date, end_date = today - datetime.timedelta(days=7), today
-        elif period == 'Last 30 days':
-            start_date, end_date = today - datetime.timedelta(days=30), today
-        elif period == 'Last 90 days':
-            start_date, end_date = today - datetime.timedelta(days=90), today
-        elif period == 'Last year':
-            start_date, end_date = today - datetime.timedelta(days=365), today
-        else:
+        start_date, end_date = DatePeriod.date_range_for_period(period)
+        if start_date is None or end_date is None:
             start_date, end_date = transactions.date_range()
+        # today = datetime.date.today()
+        # if period == 'Last 7 days':
+        #     start_date, end_date = today - datetime.timedelta(days=7), today
+        # elif period == 'Last 30 days':
+        #     start_date, end_date = today - datetime.timedelta(days=30), today
+        # elif period == 'Last 90 days':
+        #     start_date, end_date = today - datetime.timedelta(days=90), today
+        # elif period == 'Last year':
+        #     start_date, end_date = today - datetime.timedelta(days=365), today
+        # else:
+        #     start_date, end_date = transactions.date_range()
         return start_date, end_date
 
     @reactive.calc
@@ -415,11 +517,12 @@ def filter_funcs_factory(
         _all_transactions = data_manager.get_transactions()
         logging.info(f"Changed period to '{current_period}'")
         start_date, end_date = _dates_for_period(current_period, _all_transactions)
-        date_range_values = _clamp_date_range(_all_transactions, start_date, end_date)
-        if date_range_values:
-            start_date, end_date, min_date, max_date = date_range_values
-        else:
-            start_date, end_date, min_date, max_date = [end_date]*4
+        min_date, max_date = start_date, end_date
+        # date_range_values = _clamp_date_range(_all_transactions, start_date, end_date)
+        # if date_range_values:
+        #     start_date, end_date, min_date, max_date = date_range_values
+        # else:
+        #     start_date, end_date, min_date, max_date = [end_date] * 4
         logging.info(f"date_range set to {min_date=} and {max_date=}")
 
         ui.update_date_range(id='transactions_date_range',
@@ -458,13 +561,12 @@ def filter_funcs_factory(
             raise ShinyTransactionFilterError(error_msg)
 
         agg_filtered_transactions = filtered_in_and_out_transactions.group_and_fill_transactions(
-            grouping_key = time_unit,
-            aggregation_key = 'sum'
+            grouping_key=time_unit,
+            aggregation_key='sum'
         )
 
         logging.info(
             f"Filtered transactions size: {agg_filtered_transactions.size()=} for filter params=({start_date, end_date, time_unit, filter_in_tags, filter_out_tags})")
-
 
         return agg_filtered_transactions
 
@@ -548,7 +650,7 @@ def render_table_standard(df,
                           format_columns=False,
                           format_boolean_values=False,
                           empty_message=None):
-    if len(df)==0 and empty_message is not None:
+    if len(df) == 0 and empty_message is not None:
         return pd.DataFrame({empty_message: ['0 rows']})
 
     if format_columns:

--- a/mecon/app/shiny_app.py
+++ b/mecon/app/shiny_app.py
@@ -3,7 +3,7 @@ import logging
 from urllib.parse import urlparse, parse_qs
 
 import pandas as pd
-from shiny import ui, Inputs, Outputs, Session, reactive, render
+from shiny import ui, Inputs, Outputs, Session, reactive, render, req
 
 from mecon import config
 from mecon.app.current_data import WorkingDataManager, WorkingDatasetDir
@@ -399,7 +399,7 @@ def filter_funcs_factory(
 
     @reactive.calc
     def filtered_transactions():
-        reactive.req(initialized.get())
+        req(initialized.get())
         start_date, end_date, time_unit, filter_in_tags, filter_out_tags = get_filter_params().values()
         transactions = data_manager.get_transactions()
 

--- a/mecon/app/shiny_app.py
+++ b/mecon/app/shiny_app.py
@@ -444,10 +444,16 @@ def filter_funcs_factory(
             error_msg = f"No transactions found for '{time_unit}' time unit after filtering out {filter_out_tags} tags."
             raise ShinyTransactionFilterError(error_msg)
 
-        logging.info(
-            f"Filtered transactions size: {filtered_in_and_out_transactions.size()=} for filter params=({start_date, end_date, time_unit, filter_in_tags, filter_out_tags})")
+        agg_filtered_transactions = filtered_in_and_out_transactions.group_and_fill_transactions(
+            grouping_key = time_unit,
+            aggregation_key = 'sum'
+        )
 
-        return filtered_in_and_out_transactions
+        logging.info(
+            f"Filtered transactions size: {agg_filtered_transactions.size()=} for filter params=({start_date, end_date, time_unit, filter_in_tags, filter_out_tags})")
+
+
+        return agg_filtered_transactions
 
     return get_filter_params, default_transactions, init, filtered_transactions
 

--- a/mecon/app/shiny_app.py
+++ b/mecon/app/shiny_app.py
@@ -399,7 +399,7 @@ def filter_funcs_factory(
 
     @reactive.calc
     def filtered_transactions():
-        reactive.req(initialized.get())
+        # reactive.req(initialized.get())
         start_date, end_date, time_unit, filter_in_tags, filter_out_tags = get_filter_params().values()
         transactions = data_manager.get_transactions()
 

--- a/mecon/app/shiny_app.py
+++ b/mecon/app/shiny_app.py
@@ -3,7 +3,7 @@ import logging
 from urllib.parse import urlparse, parse_qs
 
 import pandas as pd
-from shiny import ui, Inputs, Outputs, Session, reactive, render
+from shiny import ui, Inputs, Outputs, Session, reactive, render, req
 
 from mecon import config
 from mecon.app.current_data import WorkingDataManager, WorkingDatasetDir

--- a/mecon/app/shiny_app.py
+++ b/mecon/app/shiny_app.py
@@ -223,6 +223,7 @@ def filter_url_params_function_factory(input: Inputs,
         filter_out_tags_raw = _get_single_param(_raw_url_params, 'filter_out_tags', '')
         params['filter_out_tags'] = filter_out_tags_raw.split(',') if len(filter_out_tags_raw) > 0 else []
         params['time_unit'] = _get_single_param(_raw_url_params, 'time_unit', DEFAULT_FILTER_TIME_UNIT)
+        params['period'] = _get_single_param(_raw_url_params, 'period')
         params['start_date'] = _parse_date(_get_single_param(_raw_url_params, 'start_date'))
         params['end_date'] = _parse_date(_get_single_param(_raw_url_params, 'end_date'))
         logging.info(f"Input params: {params=}")
@@ -238,6 +239,8 @@ def filter_funcs_factory(
 ):
     filter_url_params_calc = filter_url_params_function_factory(input, output, session, data_manager)
     initialized = reactive.Value(False)
+    skip_period_sync = reactive.Value(False)
+    last_period = reactive.Value(None)
 
     def _clamp_date_range(transactions, start_date: datetime.date, end_date: datetime.date):
         min_date, max_date = transactions.date_range()
@@ -330,9 +333,19 @@ def filter_funcs_factory(
         with reactive.isolate():
             current_period = input.date_period_input_select()
 
-        has_custom_dates = filter_url_params['start_date'] is not None and filter_url_params['end_date'] is not None
+        requested_period = filter_url_params.get('period')
+        if requested_period:
+            ui.update_select(id='date_period_input_select', selected=requested_period)
+            current_period = requested_period
+
+        start_date_override = filter_url_params['start_date']
+        end_date_override = filter_url_params['end_date']
+        has_custom_dates = start_date_override is not None or end_date_override is not None
+
         if has_custom_dates:
-            start_date, end_date = filter_url_params['start_date'], filter_url_params['end_date']
+            start_date = start_date_override
+            end_date = end_date_override
+            skip_period_sync.set(True)
         else:
             start_date, end_date = _dates_for_period(current_period, all_transactions)
 
@@ -343,6 +356,7 @@ def filter_funcs_factory(
                              min=min_date,
                              max=max_date)
 
+        last_period.set(current_period)
         initialized.set(True)
 
         # if len(input.compare_tags_select()) == 0:  TODO
@@ -384,9 +398,14 @@ def filter_funcs_factory(
     def period_change_effect():
         if not initialized.get():
             return
+        current_period = input.date_period_input_select()
+        if skip_period_sync.get() and current_period == last_period.get():
+            skip_period_sync.set(False)
+            return
+        skip_period_sync.set(False)
         _all_transactions = data_manager.get_transactions()
-        logging.info(f"Changed period to '{input.date_period_input_select()}'")
-        start_date, end_date = _dates_for_period(input.date_period_input_select(), _all_transactions)
+        logging.info(f"Changed period to '{current_period}'")
+        start_date, end_date = _dates_for_period(current_period, _all_transactions)
         start_date, end_date, min_date, max_date = _clamp_date_range(_all_transactions, start_date, end_date)
         logging.info(f"date_range set to {min_date=} and {max_date=}")
 
@@ -396,11 +415,17 @@ def filter_funcs_factory(
                              min=min_date,
                              max=max_date
                              )
+        last_period.set(current_period)
 
     @reactive.calc
     def filtered_transactions():
         req(initialized.get())
-        start_date, end_date, time_unit, filter_in_tags, filter_out_tags = get_filter_params().values()
+        params = get_filter_params()
+        start_date = params['start_date']
+        end_date = params['end_date']
+        time_unit = params['time_unit']
+        filter_in_tags = params['filter_in_tags']
+        filter_out_tags = params['filter_out_tags']
         transactions = data_manager.get_transactions()
 
         in_date_range_transactions = transactions.select_date_range(start_date, end_date)

--- a/mecon/config.py
+++ b/mecon/config.py
@@ -74,7 +74,7 @@ EXPECTED_MONZO_COLUMNS_IN_RAW_STATEMENT = {'Transaction',
                                            "Money Out", "Money In"}
 
 
-SHINY_DEFAULT_FILTER_PERIOD = 'Last 30 days'
-SHINY_DEFAULT_FILTER_TIME_UNIT = 'month'
+SHINY_DEFAULT_FILTER_PERIOD = 'Last 7 days'
+SHINY_DEFAULT_FILTER_TIME_UNIT = 'day'
 
 logging.info(f"Configuration has been set.")

--- a/mecon/data/additional_tags.py
+++ b/mecon/data/additional_tags.py
@@ -63,10 +63,11 @@ class HighLevelDataProviderTagSet(set):
 
         providers_mapping = {}
         for source in all_statements_sources.sources:
+            prov_name = f"{source.original_provider}"
             if source.original_provider in providers_mapping:
-                providers_mapping[source.original_provider].append(source)
+                providers_mapping[prov_name].append(source)
             else:
-                providers_mapping[source.original_provider] = [source]
+                providers_mapping[prov_name] = [source]
 
         high_level_sources = {
             Tag.from_json(

--- a/mecon/data/data_management.py
+++ b/mecon/data/data_management.py
@@ -228,6 +228,183 @@ class DataCache:
         self.reset_tags_metadata()
 
 
+class CachedFileDataManagerLegacy:
+    def __init__(self, dataset: Dataset):
+        assert dataset is not None, "None given as dataset"
+        self.dataset = dataset
+        self.statements_dirpath = self.dataset.statements
+
+        self.transactions = None
+        self._transactions_path = self.dataset.current_data / 'transactions.csv'
+        self._load_transactions()
+
+        self.tags_df = None
+        self._tags_path = self.dataset.current_data / 'tags.csv'
+        self._load_tags()
+
+        self.tags_metadata_df = None
+        self._tags_metadata_path = self.dataset.current_data / 'tags_metadata.csv'
+        self._load_tags_metadata()
+        pass
+
+    def _load_transactions(self):
+        self.transactions = Transactions.from_csv(self._transactions_path) if self._transactions_path.exists() else None
+
+    def _load_tags(self):
+        self.tags_df = pd.read_csv(self._tags_path, index_col=None) if self._tags_path.exists() else None
+
+    def _load_tags_metadata(self):
+        self.tags_metadata_df = pd.read_csv(self._tags_metadata_path,
+                                            index_col=None) if self._tags_metadata_path.exists() else None
+
+    def _save_transactions(self):
+        self.transactions.dataframe().to_csv(self._transactions_path, index=False)
+
+    def _save_tags(self):
+        self.tags_df.to_csv(self._tags_path, index=False)
+
+    def _save_tags_metadata(self):
+        self.tags_metadata_df.to_csv(self._tags_metadata_path, index=False)
+
+    def get_statement_filepaths(self) -> dict[str, list[pathlib.Path]]:
+        # all_statement_paths = list(self.statements_dirpath.rglob("*.csv"))
+        # sources_and_filenames = {}
+        # for statement_filepath in all_statement_paths_dict:
+        #     key = str(statement_filepath.parent.name)
+        #     if key not in sources_and_filenames:
+        #         sources_and_filenames[key] = []
+        #
+        #     sources_and_filenames[key].append(statement_filepath)
+
+        sources_and_filenames = self.dataset.statement_files()
+        return sources_and_filenames
+
+    def get_statements(self) -> dict[str, list[pd.DataFrame]]:
+        filepaths = self.get_statement_filepaths()
+        sources_and_statements = {
+            source: [transformers.StatementTransformer.factory(source).read_df(filepath) for filepath in filepaths]
+            for source, filepaths in filepaths.items() if source in transformers.StatementTransformer.SOURCES}
+        return sources_and_statements
+
+    def get_transformed_statements(self) -> dict[str, pd.DataFrame]:
+        sources_and_statements = self.get_statements().copy()
+        sources_and_merged_statenents = {}
+        for source, statements in sources_and_statements.items():
+            try:
+                merged_statements = pd.concat(statements)
+                transformer = transformers.StatementTransformer.factory(source)
+                transformed_statement = transformer.transform(merged_statements)
+                sources_and_merged_statenents[source] = transformed_statement
+            except ValueError:
+                # del sources_and_statements[source]
+                logging.error(f"Failed to parse '{source}' statements, {len(statements)} files.")
+                raise
+            except Exception as e:
+                raise
+
+        return sources_and_merged_statenents
+
+    def reset_transactions(self):
+        sources_and_statements = self.get_transformed_statements()
+        df_merged = pd.concat(sources_and_statements.values())
+        df_merged.sort_values(by=["datetime"], inplace=True)
+
+        self.transactions = Transactions(df_merged)
+        df_merged['tags'] = ''  # '[[] for _ in range(len(df_merged))]
+        self._save_transactions()
+        # logging.info(f"Wrote {self.transactions.size()} transactions to {self.dataset.current_data}")
+        return self
+
+    def get_transactions(self) -> Transactions:
+        return self.transactions
+
+    def get_tagged_transactions(self) -> Transactions:
+        if 'tags' not in self.transactions.dataframe().columns:
+            self.reset_transaction_tags()
+        return self.transactions
+
+    def get_tag(self, tag_name) -> Tag | None:
+        tags_dict = self.tags_df.set_index('name').to_dict('index')
+
+        if tag_name not in tags_dict:
+            return None
+
+        tag = Tag.from_json_string(tag_name, tags_dict[tag_name]['conditions_json'])
+
+        return tag
+
+    def update_tag(self, tag: Tag, update_tags=True):
+        tags_dict = self.tags_df.set_index('name').to_dict('index')
+
+        tag_name = tag.name
+        if tag_name not in tags_dict:
+            tags_dict[tag_name] = {
+                'conditions_json': None,
+                'date_created': datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S'),
+            }
+        tags_dict[tag_name]['conditions_json'] = json.dumps(tag.rule.to_json())
+        self.tags_df = pd.DataFrame.from_dict(tags_dict, orient='index').reset_index().rename(columns={'index': 'name'})
+        if update_tags:
+            self.reset_transaction_tags()
+
+        self._save_tags()
+
+    def delete_tag(self, tag_name: str, update_tags=True):
+        tags_dict = self.tags_df.set_index('name').to_dict('index')
+
+        if tag_name not in tags_dict:
+            return
+
+        del tags_dict[tag_name]
+        self.tags_df = pd.DataFrame.from_dict(tags_dict, orient='index').reset_index().rename(columns={'index': 'name'})
+
+        if update_tags:
+            self.reset_transaction_tags()
+
+        self._save_tags()
+
+    def all_tags(self) -> List[Tag]:
+        tags = [Tag.from_json_string(row['name'], row['conditions_json']) for i, row in self.tags_df.iterrows()]
+        return tags
+
+    def reset_transaction_tags(self):
+        transactions = self.get_transactions().reset_tags()
+        all_tags = self.all_tags()
+
+        sess = OptREPTagging(all_tags) \
+            .create_rule_execution_plan() \
+            .create_optimised_rule_execution_plan()
+        transactions = sess.tag(transactions,
+                                monitor=RuleExecutionPlanMonitor(self.dataset))
+        self.transactions = transactions
+        self._save_transactions()
+
+        tags_metadata = tag_stats_from_transactions(transactions)
+        self.replace_tags_metadata(tags_metadata)
+
+    def get_tags_metadata(self):
+        if self.tags_metadata_df is None:
+            path = self.dataset.current_data / 'tags_metadata.csv'
+            self.tags_metadata_df = pd.read_csv(path, index_col=None)
+
+        self.all_tags()  # load tags if not already loaded
+        df_metadata = self.tags_df.merge(self.tags_metadata_df, on='name')
+        del df_metadata['conditions_json']
+
+        return df_metadata
+
+    def replace_tags_metadata(self, metadata_df: pd.DataFrame):
+        self.tags_metadata_df = metadata_df
+        self.tags_metadata_df['date_modified'] = datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S')
+        self._save_tags_metadata()
+
+    def reset(self):
+        self.reset_transactions()
+        self._load_tags()
+        self.reset_transaction_tags()
+
+
+
 class CachedFileDataManager:
     def __init__(self, dataset: Dataset):
         assert dataset is not None, "None given as dataset"
@@ -408,182 +585,6 @@ class CachedFileDataManager:
     def replace_tags_metadata(self, metadata_df: pd.DataFrame):
         if metadata_df.empty:
             logging.warning(f"An empty metadata dataframe was found for this {self.dataset.name} and will replace the old one")
-        self.tags_metadata_df = metadata_df
-        self.tags_metadata_df['date_modified'] = datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S')
-        self._save_tags_metadata()
-
-    def reset(self):
-        self.reset_transactions()
-        self._load_tags()
-        self.reset_transaction_tags()
-
-
-class CachedFileDataManagerLegacy:
-    def __init__(self, dataset: Dataset):
-        assert dataset is not None, "None given as dataset"
-        self.dataset = dataset
-        self.statements_dirpath = self.dataset.statements
-
-        self.transactions = None
-        self._transactions_path = self.dataset.current_data / 'transactions.csv'
-        self._load_transactions()
-
-        self.tags_df = None
-        self._tags_path = self.dataset.current_data / 'tags.csv'
-        self._load_tags()
-
-        self.tags_metadata_df = None
-        self._tags_metadata_path = self.dataset.current_data / 'tags_metadata.csv'
-        self._load_tags_metadata()
-        pass
-
-    def _load_transactions(self):
-        self.transactions = Transactions.from_csv(self._transactions_path) if self._transactions_path.exists() else None
-
-    def _load_tags(self):
-        self.tags_df = pd.read_csv(self._tags_path, index_col=None) if self._tags_path.exists() else None
-
-    def _load_tags_metadata(self):
-        self.tags_metadata_df = pd.read_csv(self._tags_metadata_path,
-                                            index_col=None) if self._tags_metadata_path.exists() else None
-
-    def _save_transactions(self):
-        self.transactions.dataframe().to_csv(self._transactions_path, index=False)
-
-    def _save_tags(self):
-        self.tags_df.to_csv(self._tags_path, index=False)
-
-    def _save_tags_metadata(self):
-        self.tags_metadata_df.to_csv(self._tags_metadata_path, index=False)
-
-    def get_statement_filepaths(self) -> dict[str, list[pathlib.Path]]:
-        # all_statement_paths = list(self.statements_dirpath.rglob("*.csv"))
-        # sources_and_filenames = {}
-        # for statement_filepath in all_statement_paths_dict:
-        #     key = str(statement_filepath.parent.name)
-        #     if key not in sources_and_filenames:
-        #         sources_and_filenames[key] = []
-        #
-        #     sources_and_filenames[key].append(statement_filepath)
-
-        sources_and_filenames = self.dataset.statement_files()
-        return sources_and_filenames
-
-    def get_statements(self) -> dict[str, list[pd.DataFrame]]:
-        filepaths = self.get_statement_filepaths()
-        sources_and_statements = {
-            source: [transformers.StatementTransformer.factory(source).read_df(filepath) for filepath in filepaths]
-            for source, filepaths in filepaths.items() if source in transformers.StatementTransformer.SOURCES}
-        return sources_and_statements
-
-    def get_transformed_statements(self) -> dict[str, pd.DataFrame]:
-        sources_and_statements = self.get_statements().copy()
-        sources_and_merged_statenents = {}
-        for source, statements in sources_and_statements.items():
-            try:
-                merged_statements = pd.concat(statements)
-                transformer = transformers.StatementTransformer.factory(source)
-                transformed_statement = transformer.transform(merged_statements)
-                sources_and_merged_statenents[source] = transformed_statement
-            except ValueError:
-                # del sources_and_statements[source]
-                logging.error(f"Failed to parse '{source}' statements, {len(statements)} files.")
-                raise
-            except Exception as e:
-                raise
-
-        return sources_and_merged_statenents
-
-    def reset_transactions(self):
-        sources_and_statements = self.get_transformed_statements()
-        df_merged = pd.concat(sources_and_statements.values())
-        df_merged.sort_values(by=["datetime"], inplace=True)
-
-        self.transactions = Transactions(df_merged)
-        df_merged['tags'] = ''  # '[[] for _ in range(len(df_merged))]
-        self._save_transactions()
-        # logging.info(f"Wrote {self.transactions.size()} transactions to {self.dataset.current_data}")
-        return self
-
-    def get_transactions(self) -> Transactions:
-        return self.transactions
-
-    def get_tagged_transactions(self) -> Transactions:
-        if 'tags' not in self.transactions.dataframe().columns:
-            self.reset_transaction_tags()
-        return self.transactions
-
-    def get_tag(self, tag_name) -> Tag | None:
-        tags_dict = self.tags_df.set_index('name').to_dict('index')
-
-        if tag_name not in tags_dict:
-            return None
-
-        tag = Tag.from_json_string(tag_name, tags_dict[tag_name]['conditions_json'])
-
-        return tag
-
-    def update_tag(self, tag: Tag, update_tags=True):
-        tags_dict = self.tags_df.set_index('name').to_dict('index')
-
-        tag_name = tag.name
-        if tag_name not in tags_dict:
-            tags_dict[tag_name] = {
-                'conditions_json': None,
-                'date_created': datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S'),
-            }
-        tags_dict[tag_name]['conditions_json'] = json.dumps(tag.rule.to_json())
-        self.tags_df = pd.DataFrame.from_dict(tags_dict, orient='index').reset_index().rename(columns={'index': 'name'})
-        if update_tags:
-            self.reset_transaction_tags()
-
-        self._save_tags()
-
-    def delete_tag(self, tag_name: str, update_tags=True):
-        tags_dict = self.tags_df.set_index('name').to_dict('index')
-
-        if tag_name not in tags_dict:
-            return
-
-        del tags_dict[tag_name]
-        self.tags_df = pd.DataFrame.from_dict(tags_dict, orient='index').reset_index().rename(columns={'index': 'name'})
-
-        if update_tags:
-            self.reset_transaction_tags()
-
-        self._save_tags()
-
-    def all_tags(self) -> List[Tag]:
-        tags = [Tag.from_json_string(row['name'], row['conditions_json']) for i, row in self.tags_df.iterrows()]
-        return tags
-
-    def reset_transaction_tags(self):
-        transactions = self.get_transactions().reset_tags()
-        all_tags = self.all_tags()
-
-        sess = OptREPTagging(all_tags) \
-            .create_rule_execution_plan() \
-            .create_optimised_rule_execution_plan()
-        transactions = sess.tag(transactions,
-                                monitor=RuleExecutionPlanMonitor(self.dataset))
-        self.transactions = transactions
-        self._save_transactions()
-
-        tags_metadata = tag_stats_from_transactions(transactions)
-        self.replace_tags_metadata(tags_metadata)
-
-    def get_tags_metadata(self):
-        if self.tags_metadata_df is None:
-            path = self.dataset.current_data / 'tags_metadata.csv'
-            self.tags_metadata_df = pd.read_csv(path, index_col=None)
-
-        self.all_tags()  # load tags if not already loaded
-        df_metadata = self.tags_df.merge(self.tags_metadata_df, on='name')
-        del df_metadata['conditions_json']
-
-        return df_metadata
-
-    def replace_tags_metadata(self, metadata_df: pd.DataFrame):
         self.tags_metadata_df = metadata_df
         self.tags_metadata_df['date_modified'] = datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S')
         self._save_tags_metadata()

--- a/mecon/etl/account_statements.py
+++ b/mecon/etl/account_statements.py
@@ -188,6 +188,9 @@ class Trading212CashISAAccountStatementsSource(AccountStatementsSource):
         super().__init__(working_dir, trans_transformer)
 
 
+class GeneralCredentialsError(Exception):
+    pass
+
 class APIAccountStatementsSource(AccountStatementsSource, abc.ABC):
     def __init__(self,
                  working_dir: str | Path,
@@ -197,7 +200,7 @@ class APIAccountStatementsSource(AccountStatementsSource, abc.ABC):
                  ):
         super().__init__(working_dir=working_dir, trans_transformer=trans_transformer)
         self.api_handler = api_handler
-        if auto_fetch:
+        if auto_fetch and self.api_handler is not None:
             self.fetch()
 
     def _log_fetch_banner(self) -> None:
@@ -210,7 +213,6 @@ class APIAccountStatementsSource(AccountStatementsSource, abc.ABC):
     def from_path_and_creds(cls, working_dir: Path, creds: DictFile):
         pass
 
-    @abc.abstractmethod
     def fetch(self, since: dt.datetime | None = None):
         """Fetch new statement data from the remote API.
 
@@ -218,7 +220,8 @@ class APIAccountStatementsSource(AccountStatementsSource, abc.ABC):
             since: Fetch transactions occurring after this datetime. If ``None``
                 the implementation should fetch all available data.
         """
-        pass
+        if self.api_handler is None:
+            raise GeneralCredentialsError(f"{self.__class__.__name__}.fetch(...) failed because of an uninitialized api_handler. Check if the credential are valid.")
 
     def fetch_if_needed_and_transform(
             self, *, force_fetch: bool = False
@@ -269,15 +272,22 @@ class TrueLayerStatements(APIAccountStatementsSource):
 
     @classmethod
     def from_path_and_creds(cls, working_dir: Path, creds: DictFile):
+        try:
+            api_handler = TrueLayerClient(creds)
+        except Exception as e:
+            logging.warning(f"Failed to initialize api_handler for {cls.__name__} because of {e}. 'fetch' functionality will be turned off.")
+            api_handler = None
+
         return cls(
             working_dir=working_dir,
             trans_transformer=transformers.TrueLayerStatementTransformer(
                 source=cls.id,
             ),
-            api_handler=TrueLayerClient(creds)
+            api_handler=api_handler
         )
 
     def fetch(self, since: dt.datetime | None = None):
+        super().fetch(since)
         fetch_datetime = datetime.now().date()
         fetch_job_id = str(uuid.uuid4())
 
@@ -362,13 +372,19 @@ class Trading212APIStatements(APIAccountStatementsSource):
 
     @classmethod
     def from_path_and_creds(cls, working_dir: Path, creds: DictFile):
+        try:
+            api_handler = Trading212Client(creds)
+        except Exception as e:
+            logging.warning(f"Failed to initialize api_handler for {cls.__name__} because of {e}. 'fetch' functionality will be turned off.")
+            api_handler = None
         return cls(
             working_dir=working_dir,
             trans_transformer=transformers.Trading212StatementTransformer(cls.id),
-            api_handler=Trading212Client(creds)
+            api_handler=api_handler
         )
 
     def fetch(self, since: dt.datetime | None = None):
+        super().fetch(since)
         fetch_datetime = datetime.now().date()
         fetch_job_id = str(uuid.uuid4())
 
@@ -484,13 +500,20 @@ class MonzoAPIStatements(APIAccountStatementsSource):
 
     @classmethod
     def from_path_and_creds(cls, working_dir: Path, creds: DictFile):
+        try:
+            api_handler = MonzoClient(creds)
+        except Exception as e:
+            logging.warning(f"Failed to initialize api_handler for {cls.__name__} because of {e}. 'fetch' functionality will be turned off.")
+            api_handler = None
+
         return cls(
             working_dir=working_dir,
             trans_transformer=transformers.MonzoAPIFileStatementTransformer(),
-            api_handler=MonzoClient(creds)
+            api_handler=api_handler
         )
 
     def fetch(self, since: dt.datetime | None = None):
+        super().fetch(since)
         fetch_datetime = datetime.now().date()
         fetch_job_id = str(uuid.uuid4())
 

--- a/mecon/etl/transformers.py
+++ b/mecon/etl/transformers.py
@@ -373,12 +373,14 @@ class Trading212StatementTransformer(StatementTransformer):
 
     def _transform(self, df: pd.DataFrame) -> pd.DataFrame:
         logging.info(f"Transforming Trading212 raw transactions ({df.shape} shape)")
-        # df = df[~df['Currency (Result)'].isna()].copy()
+        if 'currency_(result)' in df.columns:
+            df = df[~df['currency_(result)'].isna()].copy()
 
         dt = pd.to_datetime(df['time'].apply(lambda s: s[:19]), format="%Y-%m-%d %H:%M:%S")
         df_transformed = pd.DataFrame({'datetime': dt})
-        df_transformed['amount'] = df['total']
-        df_transformed['amount_cur'] = df['total']
+        df['sign'] = df['action'].apply(lambda a: -1 if a=='Market buy' else 1)
+        df_transformed['amount'] = df['total']*df['sign']
+        df_transformed['amount_cur'] = df['total']*df['sign']
         df_transformed['currency'] = df['currency_(total)']
 
         cols_to_concat = df.columns.difference(df_transformed.columns).difference(['time', 'total', 'id'])
@@ -395,6 +397,10 @@ class Trading212StatementTransformer(StatementTransformer):
         df_final = df_transformed[['id', 'datetime', 'amount', 'currency', 'amount_cur', 'description']]
 
         return df_final
+
+if __name__ == '__main__':
+    t = Trading212StatementTransformer()
+    t.transform(t.read_df(r"C:\Users\dimitris\PycharmProjects\datasets\20250924\data\statements\Trading212API\from_2024-11-25_to_2025-10-29_MTc2MTc4MDMwNzkzNQ.csv"))
 
 
 class TrueLayerStatementTransformer(StatementTransformer):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ httpx==0.28.1
 Monzo-API==0.3.0
 monzo==0.10.0
 httpx==0.28.1
+dateparser==1.2.2

--- a/tests/tests_with_datasets/test_shiny_filter_app.py
+++ b/tests/tests_with_datasets/test_shiny_filter_app.py
@@ -61,9 +61,13 @@ def shiny_filter_context(dataset_manager, monkeypatch):
     def update_date_range(*, id, start=None, end=None, **kwargs):
         _set_input_value(id, (start, end))
 
+    def update_select(*, id, selected=None, **kwargs):
+        _set_input_value(id, selected)
+
     monkeypatch.setattr(shiny_module.ui, "update_selectize", update_selectize)
     monkeypatch.setattr(shiny_module.ui, "update_radio_buttons", update_radio_buttons)
     monkeypatch.setattr(shiny_module.ui, "update_date_range", update_date_range)
+    monkeypatch.setattr(shiny_module.ui, "update_select", update_select)
 
     get_filter_params, default_transactions, init_effect, filtered_transactions = shiny_module.filter_funcs_factory(
         session.input,
@@ -95,11 +99,13 @@ def test_url_params_seed_filter_inputs(shiny_filter_context):
         time_unit = ctx.session.input["time_unit_select"]()
         include_tags = ctx.session.input["filter_in_tags_select"]()
         start_date, end_date = ctx.session.input["transactions_date_range"]()
+        period = ctx.session.input["date_period_input_select"]()
 
     assert time_unit == "month"
     assert include_tags == ["Commute"]
     assert start_date == datetime.date(2024, 3, 1)
     assert end_date == datetime.date(2024, 3, 25)
+    assert period == "All"
 
 
 def test_filtered_transactions_respects_tag_filters(shiny_filter_context):
@@ -138,3 +144,26 @@ def test_filtered_transactions_respects_date_range(shiny_filter_context):
     assert len(filtered_df) == 1
     assert all("2024-03-04" in ts for ts in filtered_df["datetime"].astype(str))
     assert all("Commute" in tags for tags in filtered_df["tags"])
+
+
+def test_period_change_resets_date_range(shiny_filter_context):
+    ctx = shiny_filter_context
+
+    with reactive.isolate():
+        ctx.session.input["transactions_date_range"].set(
+            (datetime.date(2024, 3, 4), datetime.date(2024, 3, 4))
+        )
+    _flush_reactive()
+
+    with reactive.isolate():
+        ctx.session.input["date_period_input_select"].set("Last 90 days")
+    _flush_reactive()
+
+    dataset_start, dataset_end = ctx.data_manager.get_transactions().date_range()
+    expected_start = max(dataset_start, datetime.date.today() - datetime.timedelta(days=90))
+    expected_end = min(dataset_end, datetime.date.today())
+
+    with reactive.isolate():
+        start_date, end_date = ctx.session.input["transactions_date_range"]()
+
+    assert (start_date, end_date) == (expected_start, expected_end)

--- a/tests/tests_with_datasets/test_shiny_filter_app.py
+++ b/tests/tests_with_datasets/test_shiny_filter_app.py
@@ -1,0 +1,140 @@
+import asyncio
+import datetime
+from types import SimpleNamespace
+
+import pytest
+from shiny import App, reactive, ui
+from shiny._connection import MockConnection
+
+
+def _flush_reactive():
+    asyncio.run(reactive.flush())
+
+
+def _trigger_initialisation(context: SimpleNamespace):
+    with reactive.isolate():
+        current = context.session.input[".clientdata_url_search"]()
+        context.session.input[".clientdata_url_search"].set(current + "&init=1")
+    _flush_reactive()
+
+
+@pytest.fixture
+def shiny_filter_context(dataset_manager, monkeypatch):
+    from shiny._validation import req as shiny_req
+    from mecon.app import shiny_app as shiny_module
+
+    if not hasattr(reactive, "req"):
+        monkeypatch.setattr(reactive, "req", shiny_req, raising=False)
+    if not hasattr(shiny_module.reactive, "req"):
+        monkeypatch.setattr(shiny_module.reactive, "req", shiny_req, raising=False)
+
+    _dataset, _manager, _root = dataset_manager
+    data_manager = shiny_module.create_data_manager()
+
+    test_app = App(ui.page_fluid(), server=lambda input, output, session: None)
+    session = test_app._create_session(MockConnection())
+
+    transactions = data_manager.get_transactions()
+    dataset_start, dataset_end = transactions.date_range()
+
+    with reactive.isolate():
+        session.input[".clientdata_url_search"] = reactive.Value(
+            "?filter_in_tags=Commute&filter_out_tags=&time_unit=month&start_date=2024-03-01&end_date=2024-03-25"
+        )
+        session.input["transactions_date_range"] = reactive.Value((dataset_start, dataset_end))
+        session.input["date_period_input_select"] = reactive.Value("All")
+        session.input["time_unit_select"] = reactive.Value("month")
+        session.input["filter_in_tags_select"] = reactive.Value([])
+        session.input["filter_out_tags_select"] = reactive.Value([])
+        session.input["compare_tags_select"] = reactive.Value([])
+
+    def _set_input_value(input_id: str, value):
+        with reactive.isolate():
+            session.input[input_id].set(value)
+
+    def update_selectize(*, id, choices=None, selected=None, **kwargs):
+        _set_input_value(id, selected if selected is not None else [])
+
+    def update_radio_buttons(*, id, selected=None, **kwargs):
+        _set_input_value(id, selected)
+
+    def update_date_range(*, id, start=None, end=None, **kwargs):
+        _set_input_value(id, (start, end))
+
+    monkeypatch.setattr(shiny_module.ui, "update_selectize", update_selectize)
+    monkeypatch.setattr(shiny_module.ui, "update_radio_buttons", update_radio_buttons)
+    monkeypatch.setattr(shiny_module.ui, "update_date_range", update_date_range)
+
+    get_filter_params, default_transactions, init_effect, filtered_transactions = shiny_module.filter_funcs_factory(
+        session.input,
+        session.output,
+        session,
+        data_manager,
+    )
+
+    context = SimpleNamespace(
+        app=test_app,
+        session=session,
+        shiny_module=shiny_module,
+        data_manager=data_manager,
+        get_filter_params=get_filter_params,
+        default_transactions=default_transactions,
+        init_effect=init_effect,
+        filtered_transactions=filtered_transactions,
+    )
+
+    _trigger_initialisation(context)
+
+    return context
+
+
+def test_url_params_seed_filter_inputs(shiny_filter_context):
+    ctx = shiny_filter_context
+
+    with reactive.isolate():
+        time_unit = ctx.session.input["time_unit_select"]()
+        include_tags = ctx.session.input["filter_in_tags_select"]()
+        start_date, end_date = ctx.session.input["transactions_date_range"]()
+
+    assert time_unit == "month"
+    assert include_tags == ["Commute"]
+    assert start_date == datetime.date(2024, 3, 1)
+    assert end_date == datetime.date(2024, 3, 25)
+
+
+def test_filtered_transactions_respects_tag_filters(shiny_filter_context):
+    ctx = shiny_filter_context
+
+    with reactive.isolate():
+        trans = ctx.default_transactions()
+    df = trans.dataframe()
+
+    assert len(df) == 2
+    assert all("Commute" in tags for tags in df["tags"])
+
+    with reactive.isolate():
+        ctx.session.input["filter_out_tags_select"].set(["Monzo"])
+    _flush_reactive()
+    with reactive.isolate():
+        filtered = ctx.filtered_transactions()
+    filtered_df = filtered.dataframe()
+
+    assert len(filtered_df) == 1
+    assert all("Monzo" not in tags for tags in filtered_df["tags"])
+
+
+def test_filtered_transactions_respects_date_range(shiny_filter_context):
+    ctx = shiny_filter_context
+
+    with reactive.isolate():
+        ctx.session.input["transactions_date_range"].set(
+            (datetime.date(2024, 3, 4), datetime.date(2024, 3, 4))
+        )
+    _flush_reactive()
+    with reactive.isolate():
+        filtered = ctx.filtered_transactions()
+
+    filtered_df = filtered.dataframe()
+    assert len(filtered_df) == 1
+    assert all("2024-03-04" in ts for ts in filtered_df["datetime"].astype(str))
+    assert all("Commute" in tags for tags in filtered_df["tags"])


### PR DESCRIPTION
## Summary
- rewrite the Shiny filter Playwright test to use the simple_filter_app fixture via a cross-platform path
- parse the rendered filter parameters and assert the default configuration and table outputs against dynamically generated expectations
- generate fresh manual datasets inside the test and clean them up to mirror the app behaviour before validating both data tables

## Testing
- not run (playwright dependency is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6903f8ee06288326b3762df39fbd5dbd