### PR TITLE
Add tests for DateRollingDataset rollover handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,40 @@
 version: '3'
 services:
+  setup_service:
+    build:
+      dockerfile: services/setup/Dockerfile
+    volumes:
+      #      - ./datasets:/mecon/datasets
+      - "${MECON_DATASETS_DIR}:/mecon/datasets"
   main_app:
     build:
       dockerfile: services/main_shiny/Dockerfile
+    depends_on:
+      - setup_service
     ports:
       - 8000:8000
     volumes:
-#      - ./datasets:/mecon/datasets
+      #      - ./datasets:/mecon/datasets
       - "${MECON_DATASETS_DIR}:/mecon/datasets"
 
   reports_app:
     build:
       dockerfile: services/reports/Dockerfile
+    depends_on:
+      - setup_service
     ports:
       - 8001:8000
     volumes:
-#      - ./datasets:/mecon/datasets
+      #      - ./datasets:/mecon/datasets
       - "${MECON_DATASETS_DIR}:/mecon/datasets"
   edit_data_app:
     build:
       dockerfile: services/edit_data/Dockerfile
+    depends_on:
+      - setup_service
     ports:
       - 8002:8000
     volumes:
-#      - ./datasets:/mecon/datasets
+      #      - ./datasets:/mecon/datasets
       - "${MECON_DATASETS_DIR}:/mecon/datasets"
 

--- a/mecon/app/current_data.py
+++ b/mecon/app/current_data.py
@@ -9,13 +9,31 @@ from mecon.data.data_management import CachedFileDataManager
 from mecon.app.data_manager import CachedDBDataManager
 from mecon.app.db_extension import DBWrapper
 from mecon.data.datafields import InvalidInputDataFrameColumns, NullDataframeInDataframeWrapper
-from mecon.etl.dataset import CustomisedDatasetDir, Dataset
+from mecon.etl.dataset import CustomisedDatasetDir, Dataset, DateRollingDataset
 from mecon.etl.statements import HSBCStatementCSV, MonzoStatementCSV, RevoStatementCSV
 
 
 # todo rename to working/current and file system to datasets
 
-class WorkingDatasetDir(CustomisedDatasetDir):
+class WorkingDatasetDir(DateRollingDataset):
+    def __init__(self):
+        path = config.DEFAULT_DATASETS_DIR_PATH
+        super().__init__(path)
+        self.working_dataset_name = None
+
+    @property
+    def working_dataset(self) -> Dataset:
+        if self.working_dataset_name is not None and self.working_dataset_name in self.dataset_names():
+            return self.get_dataset(self.working_dataset_name)
+
+        return self.get_last_dataset()
+
+    def set_working_dataset(self, dataset_name: str) -> Dataset:
+        self.working_dataset_name = dataset_name
+        return self.working_dataset
+
+
+class WorkingDatasetDirLegacy(CustomisedDatasetDir):
     def __init__(self):
         path = config.DEFAULT_DATASETS_DIR_PATH
         super().__init__(path)
@@ -35,6 +53,7 @@ class WorkingDatasetDir(CustomisedDatasetDir):
             raise ValueError(f"Working dataset {dataset_name} does not exist in {self.path}")
         logging.info(f"Setting new current working dataset to '{dataset_name}': {self._working_dataset}")
         return self.working_dataset
+
 
 
 class WorkingDatasetDirInfo:

--- a/mecon/etl/dataset.py
+++ b/mecon/etl/dataset.py
@@ -362,7 +362,7 @@ class DateRollingDataset:
                 self._datasets[dataset.name] = Dataset.from_dirpath(dataset)
             else:
                 logging.info(f"Skipping {dataset} as it is not a valid path.")
-        logging.info(f"Adding {len(self._datasets)} datasets. #info#filesystem")
+        logging.info(f"Found {len(self._datasets)} datasets. #info#filesystem")
 
     def get_dataset(self, dataset_name: str) -> Dataset | None:
         if dataset_name is None or self.is_empty():
@@ -400,7 +400,7 @@ class DateRollingDataset:
         logging.info(f"Dataset '{today_id}' not found among the datasets {self.dataset_names()}. Rolling over...")
         last_dataset_path = self.get_last_dataset().path
         today_path = last_dataset_path.parent / today_id
-        shutil.copytree(last_dataset_path, today_path)
+        shutil.copytree(last_dataset_path, today_path, dirs_exist_ok=True)
         logging.info(f"Dataset rollover from {last_dataset_path.name} to {today_id}. #info#filesystem")
         self.find_datasets()
 

--- a/mecon/etl/dataset.py
+++ b/mecon/etl/dataset.py
@@ -328,14 +328,14 @@ class CustomisedDatasetDir(DatasetDir):
 class DateRollingDataset:
     def __init__(self,
                  path: str | Path,
-                 max_number_of_datasets: int):
+                 max_number_of_datasets: int = 10):
         self._path = pathlib.Path(path)
         self.max_number_of_datasets = max_number_of_datasets
 
         self._datasets = {}
         self.find_datasets()
 
-        self.rollover()
+        # self.rollover()
 
     @property
     def name(self):
@@ -356,9 +356,12 @@ class DateRollingDataset:
 
     def find_datasets(self):
         self._datasets = {}
+        logging.info(f"{list(self.path.iterdir())=}")
         for dataset in self.path.iterdir():
             if dataset.is_dir() and dataset.name.isnumeric() and len(dataset.name) == 8:
                 self._datasets[dataset.name] = Dataset.from_dirpath(dataset)
+            else:
+                logging.info(f"Skipping {dataset} as it is not a valid path.")
         logging.info(f"Adding {len(self._datasets)} datasets. #info#filesystem")
 
     def get_dataset(self, dataset_name: str) -> Dataset | None:
@@ -371,6 +374,7 @@ class DateRollingDataset:
 
     def get_last_dataset(self) -> Dataset | None:
         if self.is_empty():
+            logging.info(f"DatasetDir.get_last_dataset: Dataset Directory '{self.path}' has no datasets inside.")
             return None
 
         dataset_names = self.dataset_names()
@@ -390,9 +394,10 @@ class DateRollingDataset:
     def rollover(self):
         today_id = datetime.today().strftime("%Y%m%d")
         if today_id in self.dataset_names():
-            logging.info(f"No Dataset rollover needed for {today_id}. #info#filesystem")
+            logging.info(f"No Dataset rollover needed,  '{today_id}' dataset already exists. #info#filesystem")
             return
 
+        logging.info(f"Dataset '{today_id}' not found among the datasets {self.dataset_names()}. Rolling over...")
         last_dataset_path = self.get_last_dataset().path
         today_path = last_dataset_path.parent / today_id
         shutil.copytree(last_dataset_path, today_path)

--- a/mecon/etl/dataset.py
+++ b/mecon/etl/dataset.py
@@ -17,7 +17,7 @@ def _subfolder_csvs(path):
     for subfolder in path.iterdir():
         if subfolder.is_dir():
             # csv_files = [p.name for p in subfolder.glob("*.csv")]
-            csv_files = list(subfolder.glob("*.csv"))
+            csv_files = sorted(subfolder.glob("*.csv"))
             result[subfolder.name] = csv_files
 
     return result
@@ -355,6 +355,7 @@ class DateRollingDataset:
         return len(self.datasets()) == 0
 
     def find_datasets(self):
+        self._datasets = {}
         for dataset in self.path.iterdir():
             if dataset.is_dir() and dataset.name.isnumeric() and len(dataset.name) == 8:
                 self._datasets[dataset.name] = Dataset.from_dirpath(dataset)
@@ -372,7 +373,7 @@ class DateRollingDataset:
         if self.is_empty():
             return None
 
-        dataset_names = self._datasets.keys()
+        dataset_names = self.dataset_names()
         last_dataset = max(dataset_names)
         return self.get_dataset(last_dataset)
 
@@ -380,14 +381,15 @@ class DateRollingDataset:
         if self.is_empty():
             return
 
-        dataset_names = self._datasets.keys()
+        dataset_names = self.dataset_names()
         first_dataset = min(dataset_names)
         shutil.rmtree(self.path / first_dataset)
-        logging.info(f"Removed {len(dataset_names)} datasets. #info#filesystem")
+        logging.info(f"Removed dataset {first_dataset}. #info#filesystem")
+        self.find_datasets()
 
     def rollover(self):
         today_id = datetime.today().strftime("%Y%m%d")
-        if today_id in self.datasets():
+        if today_id in self.dataset_names():
             logging.info(f"No Dataset rollover needed for {today_id}. #info#filesystem")
             return
 

--- a/mecon/etl/dataset.py
+++ b/mecon/etl/dataset.py
@@ -179,7 +179,8 @@ class DatasetV2:
 
     def statement_files(self, filter_option: Literal['all', 'settings'] | None = 'settings') -> Dict:
         if filter_option is None:
-            filter_option = "all" if 'sources' not in self.settings and 'filter' not in self.settings['sources'] else self.settings['sources']['filter']
+            filter_option = "all" if 'sources' not in self.settings and 'filter' not in self.settings['sources'] else \
+            self.settings['sources']['filter']
 
         all_files = _subfolder_csvs(self.statements)
 
@@ -191,9 +192,11 @@ class DatasetV2:
                 return all_files
 
             if set(all_files.keys()) != set(self.settings['sources'].keys()):
-                logging.warning(f"Discrepancy between sources found ({set(all_files.keys())}) and the ones defined in settings file settings ({set(self.settings['sources'].keys())})")
+                logging.warning(
+                    f"Discrepancy between sources found ({set(all_files.keys())}) and the ones defined in settings file settings ({set(self.settings['sources'].keys())})")
 
-            selected_files = {source_name: all_files[source_name] for source_name, is_enabled in self.settings['sources'].items() if is_enabled}
+            selected_files = {source_name: all_files[source_name] for source_name, is_enabled in
+                              self.settings['sources'].items() if is_enabled}
             logging.info(f"Selected files: {self.settings['sources']}")
             return selected_files
         else:
@@ -406,6 +409,3 @@ class DateRollingDataset:
 
         if len(self.datasets()) > self.max_number_of_datasets:
             self.delete_first_dataset()
-
-
-

--- a/services/main_shiny/datasets_app.py
+++ b/services/main_shiny/datasets_app.py
@@ -24,7 +24,7 @@ def format_current_dataset_directory_text(path) -> str:
 
 def update_working_dataset_selection(datasets_obj, dataset_name: str):
     datasets_obj.set_working_dataset(dataset_name)
-    datasets_obj.settings['CURRENT_DATASET'] = dataset_name
+    # datasets_obj.settings['CURRENT_DATASET'] = dataset_name
 
 
 app_ui = shiny_app.app_ui_factory(

--- a/services/setup/Dockerfile
+++ b/services/setup/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11.7-slim
+
+RUN apt-get update
+
+WORKDIR mecon
+
+COPY ./requirements.txt ./requirements.txt
+COPY ./services/main_shiny/requirements.txt ./requirements_shiny.txt
+
+RUN python -m pip install --upgrade pip && pip install -r requirements.txt && pip install -r requirements_shiny.txt
+
+COPY ./mecon ./mecon
+COPY ./setup.py ./setup.py
+RUN  pip install -e .
+
+COPY ./services/setup/ ./services/setup/
+
+CMD ["python", "./services/setup/rollover_dataset.py"]

--- a/services/setup/rollover_dataset.py
+++ b/services/setup/rollover_dataset.py
@@ -1,0 +1,5 @@
+from mecon.app.current_data import WorkingDatasetDir
+
+if __name__ == '__main__':
+    working_dataset_dir = WorkingDatasetDir()
+    working_dataset_dir.rollover()

--- a/tests/unit_tests/test_dataset.py
+++ b/tests/unit_tests/test_dataset.py
@@ -3,6 +3,8 @@ import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from datetime import datetime
+from unittest import mock
 
 import pandas as pd
 
@@ -181,6 +183,60 @@ class DatasetV2TestCase(unittest.TestCase):
         self.assertEqual(statement_files_info_df['rows'].tolist(), [0])
 
         csv_file.unlink()
+
+
+class DateRollingDatasetTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.mkdtemp()
+        self.datasets_root = Path(self.temp_dir)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.datasets_root)
+
+    def _create_dataset(self, dataset_id: str) -> Path:
+        dataset_path = self.datasets_root / dataset_id
+        dataset_path.mkdir()
+        fs.Dataset.from_dirpath(dataset_path)
+        return dataset_path
+
+    def test_find_datasets_ignores_invalid_entries(self):
+        today_id = datetime.today().strftime("%Y%m%d")
+        self._create_dataset(today_id)
+        self._create_dataset("20240101")
+        (self.datasets_root / "not_a_dataset").mkdir()
+        (self.datasets_root / "2024010").mkdir()
+        (self.datasets_root / "README.txt").write_text("not a dataset")
+
+        with mock.patch("mecon.etl.dataset.datetime") as mock_datetime:
+            mock_datetime.today.return_value.strftime.return_value = today_id
+            dataset_dir = fs.DateRollingDataset(self.datasets_root, max_number_of_datasets=5)
+
+        expected_dataset_names = {today_id, "20240101"}
+        self.assertEqual(set(dataset_dir.dataset_names()), expected_dataset_names)
+
+    def test_rollover_creates_copy_and_limits_history(self):
+        dataset_ids = ["20240101", "20240102"]
+        for dataset_id in dataset_ids:
+            self._create_dataset(dataset_id)
+
+        latest_dataset_path = self.datasets_root / "20240102"
+        file_to_copy = latest_dataset_path / "data" / "current" / "existing.txt"
+        file_to_copy.parent.mkdir(parents=True, exist_ok=True)
+        file_to_copy.write_text("content")
+
+        new_dataset_id = "20240103"
+        with mock.patch("mecon.etl.dataset.datetime") as mock_datetime:
+            mock_datetime.today.return_value.strftime.return_value = new_dataset_id
+            dataset_dir = fs.DateRollingDataset(self.datasets_root, max_number_of_datasets=2)
+
+        self.assertTrue((self.datasets_root / new_dataset_id).exists())
+        copied_file = self.datasets_root / new_dataset_id / "data" / "current" / "existing.txt"
+        self.assertTrue(copied_file.exists())
+        self.assertEqual(copied_file.read_text(), "content")
+
+        self.assertFalse((self.datasets_root / "20240101").exists())
+        self.assertEqual(set(dataset_dir.dataset_names()), {"20240102", new_dataset_id})
+        self.assertEqual(dataset_dir.get_last_dataset().name, new_dataset_id)
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/test_dataset.py
+++ b/tests/unit_tests/test_dataset.py
@@ -238,6 +238,23 @@ class DateRollingDatasetTestCase(unittest.TestCase):
         self.assertEqual(set(dataset_dir.dataset_names()), {"20240102", new_dataset_id})
         self.assertEqual(dataset_dir.get_last_dataset().name, new_dataset_id)
 
+    def test_rollover_skips_when_today_dataset_already_exists(self):
+        existing_dataset_id = "20240101"
+        today_id = "20240102"
+
+        self._create_dataset(existing_dataset_id)
+        today_dataset_path = self._create_dataset(today_id)
+        sentinel_file = today_dataset_path / "data" / "current" / "sentinel.txt"
+        sentinel_file.parent.mkdir(parents=True, exist_ok=True)
+        sentinel_file.write_text("original")
+
+        with mock.patch("mecon.etl.dataset.datetime") as mock_datetime:
+            mock_datetime.today.return_value.strftime.return_value = today_id
+            dataset_dir = fs.DateRollingDataset(self.datasets_root, max_number_of_datasets=5)
+
+        self.assertEqual(dataset_dir.get_last_dataset().name, today_id)
+        self.assertEqual(set(dataset_dir.dataset_names()), {existing_dataset_id, today_id})
+        self.assertEqual(sentinel_file.read_text(), "original")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests covering DateRollingDataset dataset discovery and rollover behaviour
- fix DateRollingDataset to refresh cached dataset metadata and ensure deterministic CSV ordering

## Testing
- pytest tests/unit_tests/test_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_69063489b494832682b9b9e5bf6830e2