### PR TITLE
Fix TrueLayer auth helpers and add dataset-backed tests

### DIFF
--- a/mecon/etl/account_statements.py
+++ b/mecon/etl/account_statements.py
@@ -343,7 +343,7 @@ class TrueLayerStatements(APIAccountStatementsSource):
         filepath.parent.mkdir(parents=True, exist_ok=True)
         df.to_csv(filepath, index_label=None)
         logging.info(f"A statement file for {self.id} with {df.shape=} rows got added to the source dir: {filepath}")
-
+        return df
 
 class TrueLayerHSBCStatements(TrueLayerStatements):
     id = 'TLHSBC'

--- a/services/auth/truelayer_auth_app.py
+++ b/services/auth/truelayer_auth_app.py
@@ -124,6 +124,8 @@ def fetch_data(source, account_id, which_data: Literal['max', 'last'] = 'last'):
 
 def source_ui(source: str):
     sid = sanitize(source)
+    accounts = get_accounts_info_from_creds(source) or []
+    account_choices = ['All'] + [account['account_id'] for account in accounts]
     return ui.layout_columns(
         ui.navset_pill(
             ui.nav_panel(
@@ -155,7 +157,7 @@ def source_ui(source: str):
                     ui.card_body(ui.input_selectize(
                         id=f"{sid}_fetch_account_select",
                         label="Select account",
-                        choices=['All'] + [account['account_id'] for account in get_accounts_info_from_creds(source)]
+                        choices=account_choices
                     ),
                         ui.input_radio_buttons(
                             id=f"{sid}_fetch_period_radio",
@@ -237,7 +239,7 @@ def mount_source_server(source: str, input, output, session):
 
         for account_id in account_ids:
             try:
-                fetch_data(input, account_id, period_selection)
+                fetch_data(source, account_id, period_selection)
                 ui.notification_show(
                     f"Fetching data from '{source}', account: '{account_id}', period: '{period_selection}'...DISABLED.",
                     type='warning',

--- a/services/auth/truelayer_auth_app.py
+++ b/services/auth/truelayer_auth_app.py
@@ -117,9 +117,13 @@ def fetch_data(source, account_id, which_data: Literal['max', 'last'] = 'last'):
     elif which_data == 'last':
         acc_data_info = source_current_data_info_cached(source)[account_id]
         last_date = acc_data_info['end_date']
-        from_date, to_date = last_date, datetime.today()
-    # tl.get_transactions(source, account_id, from_date, to_date)
-    raise ValueError(f"ERROR for inputs: {source=} {account_id=}, {which_data=}, {from_date=}, {to_date=}")
+        from_date, to_date = datetime.strptime(last_date, "%Y-%m-%d"), datetime.today()
+
+    logging.info(
+        f"Fetching data from '{source}', account: '{account_id}', period: '{which_data}', {from_date=}, {to_date=} ")
+    account_statement = TrueLayerStatements.from_account_id(dataset, account_id)
+    df = account_statement.fetch(since=from_date)
+    return df
 
 
 def source_ui(source: str):
@@ -154,18 +158,21 @@ def source_ui(source: str):
                 "Data",
                 ui.card(
                     ui.card_header("Data"),
-                    ui.card_body(ui.input_selectize(
-                        id=f"{sid}_fetch_account_select",
-                        label="Select account",
-                        choices=account_choices
-                    ),
-                        ui.input_radio_buttons(
-                            id=f"{sid}_fetch_period_radio",
-                            label="Period",
-                            choices={'last': 'Since last fetch', 'max': 'All available (90 days)'},
-                            selected='last',
-                        ),
-                        ui.input_task_button(id=f"fetch_{sid}_button", label="Fetch data...")
+                    ui.card_body(
+                        ui.row(
+                            ui.input_selectize(
+                                id=f"{sid}_fetch_account_select",
+                                label="Select account",
+                                choices=account_choices
+                            ),
+                            ui.input_radio_buttons(
+                                id=f"{sid}_fetch_period_radio",
+                                label="Period",
+                                choices={'last': 'Since last fetch', 'max': 'All available (90 days)'},
+                                selected='last',
+                            ),
+                            ui.input_task_button(id=f"fetch_{sid}_button", label="Fetch data...", width='10%', height='10%'),
+                        )
                     ),
                     ui.card_footer(
                         ui.output_ui(id=f"{sid}_data_info")
@@ -239,11 +246,14 @@ def mount_source_server(source: str, input, output, session):
 
         for account_id in account_ids:
             try:
-                fetch_data(source, account_id, period_selection)
+                df = fetch_data(source, account_id, period_selection)
+
+                if source in _source_current_data_info_cache:
+                    del _source_current_data_info_cache[source]
                 ui.notification_show(
-                    f"Fetching data from '{source}', account: '{account_id}', period: '{period_selection}'...DISABLED.",
-                    type='warning',
-                    duration=2
+                    f"Fetching data from '{source}', account: '{account_id}', period: '{period_selection}' returned results with shape {df.shape}",
+                    type='message',
+                    duration=5
                 )
             except Exception as e:
                 ui.notification_show(

--- a/tests/tests_with_datasets/conftest.py
+++ b/tests/tests_with_datasets/conftest.py
@@ -52,6 +52,9 @@ def dataset_manager(tmp_path, monkeypatch):
         current_dir / "op_monitoring.csv", index=False
     )
 
+    rolling_dataset = datasets_root / "20240301"
+    shutil.copytree(target_dataset, rolling_dataset)
+
     (datasets_root / "settings.json").write_text(
         json.dumps({"CURRENT_DATASET": "test_statements_and_tags"})
     )
@@ -68,7 +71,14 @@ def dataset_manager(tmp_path, monkeypatch):
                         "refresh_token": "refresh",
                         "expires_at": "1970-01-01T00:00:00Z",
                         "fetched_at": "1970-01-01T00:00:00Z",
-                    }
+                    },
+                    "accounts": [
+                        {
+                            "account_id": "d4aa58643585c1e3a5f7d3e24cf5e829",
+                            "display_name": "HSBC Current Account",
+                            "currency": "GBP",
+                        }
+                    ],
                 }
             },
         },

--- a/tests/tests_with_datasets/test_truelayer_auth_app.py
+++ b/tests/tests_with_datasets/test_truelayer_auth_app.py
@@ -1,4 +1,5 @@
 import importlib
+import unittest
 
 import pytest
 
@@ -88,3 +89,7 @@ def test_format_helpers_include_account_data(truelayer_auth_app_module):
     assert "TrueLayerHSBC" in data_html
     assert "2024-03-01" in data_html
     assert "2024-03-06" in data_html
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/tests_with_datasets/test_truelayer_auth_app.py
+++ b/tests/tests_with_datasets/test_truelayer_auth_app.py
@@ -1,0 +1,90 @@
+import importlib
+
+import pytest
+
+
+@pytest.fixture()
+def truelayer_auth_app_module(dataset_manager):
+    module = importlib.import_module("services.auth.truelayer_auth_app")
+    module = importlib.reload(module)
+    module._source_current_data_info_cache.clear()
+    return module
+
+
+def test_get_accounts_info_from_creds_returns_copy(truelayer_auth_app_module):
+    module = truelayer_auth_app_module
+    source = "ob-hsbc"
+
+    accounts = module.get_accounts_info_from_creds(source)
+    assert accounts, "Expected TrueLayer accounts data to be present"
+
+    expected_len = len(module.creds["truelayer"]["sources"][source]["accounts"])
+    accounts.append({"account_id": "dummy"})
+
+    assert len(module.creds["truelayer"]["sources"][source]["accounts"]) == expected_len
+
+
+def test_get_account_ids_for_source_matches_creds(truelayer_auth_app_module):
+    module = truelayer_auth_app_module
+    source = "ob-hsbc"
+
+    expected_ids = [
+        account["account_id"]
+        for account in module.creds["truelayer"]["sources"][source]["accounts"]
+    ]
+
+    assert module.get_account_ids_for_source(source) == expected_ids
+
+
+def test_source_current_data_info_uses_dataset_transactions(truelayer_auth_app_module):
+    module = truelayer_auth_app_module
+    source = "ob-hsbc"
+    expected_account_id = "d4aa58643585c1e3a5f7d3e24cf5e829"
+
+    info = module.source_current_data_info(source)
+
+    assert expected_account_id in info
+    hsbc_info = info[expected_account_id]
+
+    assert hsbc_info["account_dir"] == "TrueLayerHSBC"
+    assert hsbc_info["start_date"] == "2024-03-01"
+    assert hsbc_info["end_date"] == "2024-03-06"
+    assert hsbc_info["days_included"] == 5
+    assert isinstance(hsbc_info["days_missing_from_today"], int)
+    assert hsbc_info["days_missing_from_today"] >= 0
+
+
+def test_source_current_data_info_cached_reuses_cache(monkeypatch, truelayer_auth_app_module):
+    module = truelayer_auth_app_module
+    module._source_current_data_info_cache.clear()
+
+    calls = []
+
+    def fake_source_info(source):
+        calls.append(source)
+        return {"dummy": {}}
+
+    monkeypatch.setattr(module, "source_current_data_info", fake_source_info)
+
+    first = module.source_current_data_info_cached("ob-hsbc")
+    second = module.source_current_data_info_cached("ob-hsbc")
+
+    assert first == {"dummy": {}}
+    assert first is second
+    assert calls == ["ob-hsbc"]
+
+
+def test_format_helpers_include_account_data(truelayer_auth_app_module):
+    module = truelayer_auth_app_module
+    source = "ob-hsbc"
+
+    accounts_html = module.format_accounts_info(
+        module.creds["truelayer"]["sources"][source]["accounts"]
+    )
+    assert "d4aa58643585c1e3a5f7d3e24cf5e829" in accounts_html
+
+    module._source_current_data_info_cache.clear()
+    data_html = module.format_data_info(source)
+    assert "TrueLayerHSBC" in data_html
+    assert "2024-03-01" in data_html
+    assert "2024-03-06" in data_html


### PR DESCRIPTION
## Summary
- prevent the TrueLayer auth UI from crashing when credentials for a source are missing
- ensure fetch actions use the correct source identifier
- extend the dataset test fixture with TrueLayer account data and add unit tests for the helper functions

## Testing
- pytest tests/tests_with_datasets/test_truelayer_auth_app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691143ba4764832698672c65230e51ef)