### PR TITLE
Add secure callback API for auth providers

### DIFF
--- a/mecon/etl/monzo_api_client.py
+++ b/mecon/etl/monzo_api_client.py
@@ -1,17 +1,15 @@
 # mecon/etl/monzo_api_client.py
 
-import logging
 import datetime
-from urllib.parse import urlparse, parse_qs
+import logging
+from urllib.parse import parse_qs, urlencode, urlparse
+
 import pandas as pd
-
-from monzo.authentication import Authentication
+from monzo.authentication import Authentication, MONZO_AUTH_URL
 from monzo.endpoints.account import Account
-from monzo.monzo import Monzo
 from monzo.errors import ForbiddenError, BadRequestError
+from monzo.monzo import Monzo
 from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError
-
-from mecon.settings import DictFile
 
 logging.basicConfig(level=logging.INFO)
 
@@ -117,8 +115,15 @@ class MonzoClient:
         return url
 
     def get_authentication_url_and_state(self):
-        url_and_state = self.monzo_auth.authentication_url
-        url, state = url_and_state.split('&state=')
+        state = self.monzo_auth.state_token
+        url = f"{MONZO_AUTH_URL}?" + urlencode(
+            {
+                "client_id": self.monzo_creds["client_id"],
+                "redirect_uri": self.monzo_creds["redirect_url"],
+                "response_type": "code",
+                "state": state,
+            }
+        )
         return url, state
 
     def _mark_pending_state(self, state: str):

--- a/mecon/etl/monzo_api_client.py
+++ b/mecon/etl/monzo_api_client.py
@@ -112,12 +112,21 @@ class MonzoClient:
 
     # -------- OAuth helpers --------
     def get_authentication_url(self):
-        return self.monzo_auth.authentication_url
+        url, state = self.get_authentication_url_and_state()
+        self._mark_pending_state(state)
+        return url
 
     def get_authentication_url_and_state(self):
-        url_and_state = self.get_authentication_url()
+        url_and_state = self.monzo_auth.authentication_url
         url, state = url_and_state.split('&state=')
         return url, state
+
+    def _mark_pending_state(self, state: str):
+        self.monzo_creds['_pending_auth'] = {
+            'state': state,
+            'created_at': datetime.datetime.utcnow().isoformat()
+        }
+        self.creds_file.save()
 
     def set_authentication_code_from_url(self, response_url: str):
         """

--- a/services/auth/app.py
+++ b/services/auth/app.py
@@ -2,6 +2,8 @@ from starlette.applications import Starlette
 from starlette.responses import RedirectResponse
 from starlette.routing import Mount, Route
 
+from callbacks import handle_callback
+
 from truelayer_auth_app import auth_app as tl_auth_app
 from monzo_auth_app import auth_app as monzo_auth_app
 
@@ -14,6 +16,7 @@ async def redirect_to_menu(request):
 routes = [
     Route('/', endpoint=redirect_to_menu),
     Route('/auth', endpoint=redirect_to_menu),
+    Route('/auth/callback/{provider}', endpoint=handle_callback, methods=["GET"]),
     Mount('/auth/truelayer', app=tl_auth_app),
     Mount('/auth/monzo', app=monzo_auth_app),
 ]

--- a/services/auth/callbacks.py
+++ b/services/auth/callbacks.py
@@ -5,6 +5,7 @@ from typing import Dict, Optional, Tuple
 import starlette.status as status
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, Response
+from starlette.responses import RedirectResponse
 
 from mecon.etl.monzo_api_client import MonzoClient
 from mecon.etl.true_layer_client_by_o3 import TrueLayerClient
@@ -49,6 +50,9 @@ def _build_success_response(message: str) -> Response:
         status_code=status.HTTP_200_OK,
     )
 
+def _build_success_redirect(to: str) -> Response:
+    return RedirectResponse(url=to, status_code=302)
+
 
 async def handle_callback(request: Request) -> Response:
     provider = request.path_params.get("provider")
@@ -68,7 +72,7 @@ async def handle_callback(request: Request) -> Response:
         )
 
     try:
-        from mecon.app import shiny_app  # Local import to avoid importing Shiny during test discovery
+        from mecon.app import shiny_app  # TODO get the creds without importing shiny_app
 
         dataset = shiny_app.get_working_dataset()
         creds = dataset.creds
@@ -125,7 +129,9 @@ async def _handle_truelayer_callback(query_params, creds: Dict) -> Response:
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 
-    return _build_success_response(f"TrueLayer: credentials stored for {bank}")
+    # return _build_success_response(f"TrueLayer: credentials stored for {bank}")
+    logging.info(f"TrueLayer: credentials stored for {bank}")
+    return _build_success_redirect(to="http://127.0.0.1:8003/auth/truelayer/")
 
 
 async def _handle_monzo_callback(request: Request, query_params, creds: Dict) -> Response:
@@ -168,4 +174,6 @@ async def _handle_monzo_callback(request: Request, query_params, creds: Dict) ->
     except Exception:
         LOGGER.exception("Failed to persist Monzo credentials")
 
-    return _build_success_response("Monzo authorisation complete")
+    # return _build_success_response("Monzo authorisation complete")
+    logging.info("Monzo authorisation complete")
+    return _build_success_redirect(to="http://127.0.0.1:8003/auth/monzo/")

--- a/services/auth/callbacks.py
+++ b/services/auth/callbacks.py
@@ -1,0 +1,171 @@
+import datetime as dt
+import logging
+from typing import Dict, Optional, Tuple
+
+import starlette.status as status
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse, Response
+
+from mecon.etl.monzo_api_client import MonzoClient
+from mecon.etl.true_layer_client_by_o3 import TrueLayerClient
+
+
+LOGGER = logging.getLogger(__name__)
+
+# Use a short window so stale or unsolicited redirects cannot overwrite creds.
+CALLBACK_MAX_AGE_MINUTES = 10
+
+
+def _parse_created_at(raw: Optional[str]) -> Optional[dt.datetime]:
+    if not raw:
+        return None
+    try:
+        return dt.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def _is_recent(raw: Optional[str]) -> bool:
+    created_at = _parse_created_at(raw)
+    if created_at is None:
+        return False
+    delta = dt.datetime.utcnow() - created_at
+    return delta <= dt.timedelta(minutes=CALLBACK_MAX_AGE_MINUTES)
+
+
+def _find_truelayer_session(creds: Dict, state: str) -> Optional[Tuple[str, str, Dict]]:
+    tl_creds = creds.get("truelayer", {})
+    for bank, details in tl_creds.get("sources", {}).items():
+        transient = details.get("_transient_store", {})
+        for provider_id, metadata in transient.items():
+            if metadata.get("state") == state:
+                return bank, provider_id, metadata
+    return None
+
+
+def _build_success_response(message: str) -> Response:
+    return HTMLResponse(
+        content=f"<html><body><h3>{message}</h3><p>You can close this window.</p></body></html>",
+        status_code=status.HTTP_200_OK,
+    )
+
+
+async def handle_callback(request: Request) -> Response:
+    provider = request.path_params.get("provider")
+    query_params = request.query_params
+
+    if provider not in {"truelayer", "monzo", "trading212"}:
+        return JSONResponse(
+            {"error": f"Unknown provider '{provider}'"},
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
+
+    if "error" in query_params:
+        # Propagate provider errors without touching local creds
+        return JSONResponse(
+            {"error": query_params.get("error"), "error_description": query_params.get("error_description")},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    try:
+        from mecon.app import shiny_app  # Local import to avoid importing Shiny during test discovery
+
+        dataset = shiny_app.get_working_dataset()
+        creds = dataset.creds
+    except Exception as exc:  # pragma: no cover - defensive; unlikely during tests
+        LOGGER.exception("Unable to load working dataset")
+        return JSONResponse(
+            {"error": "server_not_ready", "detail": str(exc)},
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    if provider == "truelayer":
+        return await _handle_truelayer_callback(query_params, creds)
+    if provider == "monzo":
+        return await _handle_monzo_callback(request, query_params, creds)
+
+    # Placeholder: prevent silent success for providers we do not yet support.
+    return JSONResponse(
+        {"error": "provider_not_configured", "detail": "Trading212 callback handling not yet implemented."},
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+    )
+
+
+async def _handle_truelayer_callback(query_params, creds: Dict) -> Response:
+    code = query_params.get("code")
+    state = query_params.get("state")
+
+    if not code or not state:
+        return JSONResponse(
+            {"error": "invalid_request", "detail": "Missing code or state."},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    session_info = _find_truelayer_session(creds, state)
+    if session_info is None:
+        return JSONResponse(
+            {"error": "unauthorised", "detail": "No matching authorisation session."},
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
+
+    bank, provider_id, metadata = session_info
+    if not _is_recent(metadata.get("created_at")):
+        return JSONResponse(
+            {"error": "expired", "detail": "Authorisation session is no longer valid."},
+            status_code=status.HTTP_410_GONE,
+        )
+
+    client = TrueLayerClient(creds)
+    try:
+        client.exchange_code(bank=bank, code=code, returned_state=state, provider_id=provider_id)
+    except Exception as exc:  # pragma: no cover - network/creds errors exercised in integration
+        LOGGER.exception("TrueLayer code exchange failed")
+        return JSONResponse(
+            {"error": "exchange_failed", "detail": str(exc)},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    return _build_success_response(f"TrueLayer: credentials stored for {bank}")
+
+
+async def _handle_monzo_callback(request: Request, query_params, creds: Dict) -> Response:
+    code = query_params.get("code")
+    state = query_params.get("state")
+
+    if not code or not state:
+        return JSONResponse(
+            {"error": "invalid_request", "detail": "Missing code or state."},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    pending = creds.get("monzo-api", {}).get("_pending_auth", {})
+    if pending.get("state") != state:
+        return JSONResponse(
+            {"error": "unauthorised", "detail": "Unknown or mismatched authorisation session."},
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
+    if not _is_recent(pending.get("created_at")):
+        return JSONResponse(
+            {"error": "expired", "detail": "Authorisation session is no longer valid."},
+            status_code=status.HTTP_410_GONE,
+        )
+
+    client = MonzoClient(creds)
+    try:
+        # Full URL preserves any extra parameters Monzo may send back.
+        client.set_authentication_code_from_url(str(request.url))
+    except Exception as exc:  # pragma: no cover - network/creds errors exercised in integration
+        LOGGER.exception("Monzo code exchange failed")
+        return JSONResponse(
+            {"error": "exchange_failed", "detail": str(exc)},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # Clear pending flag so repeated callbacks are rejected.
+    creds["monzo-api"].pop("_pending_auth", None)
+    try:
+        creds.save()
+    except Exception:
+        LOGGER.exception("Failed to persist Monzo credentials")
+
+    return _build_success_response("Monzo authorisation complete")

--- a/services/auth/monzo_auth_app.py
+++ b/services/auth/monzo_auth_app.py
@@ -39,15 +39,18 @@ def get_accounts_info_from_creds():
     if 'token' in creds['monzo-api']:
         accounts[0]['token_info'] = {}
         accounts[0]['token_info']['expires_at'] = creds['monzo-api']['token']['expires_at'] if 'expires_at' in \
-                                                                                            creds['monzo-api'][
-                                                                                                'token'] else 'No expires_at field'
+                                                                                               creds['monzo-api'][
+                                                                                                   'token'] else 'No expires_at field'
 
-        accounts[0]['token_info']['expiry'] = str(datetime.fromtimestamp(creds['monzo-api']['token']['expiry'])) if 'expiry' in \
-                                                                                                            creds[
-                                                                                                                'monzo-api'][
-                                                                                                                'token'] else 'No expiry field',
-        accounts[0]['token_info']['refresh_token'] = '****' if 'refresh_token' in creds['monzo-api']['token'] else 'No refresh_token field'
-        accounts[0]['token_info']['access_token'] = '****' if 'access_token' in creds['monzo-api']['token'] else 'No access_token field'
+        accounts[0]['token_info']['expiry'] = str(
+            datetime.fromtimestamp(creds['monzo-api']['token']['expiry'])) if 'expiry' in \
+                                                                              creds[
+                                                                                  'monzo-api'][
+                                                                                  'token'] else 'No expiry field',
+        accounts[0]['token_info']['refresh_token'] = '****' if 'refresh_token' in creds['monzo-api'][
+            'token'] else 'No refresh_token field'
+        accounts[0]['token_info']['access_token'] = '****' if 'access_token' in creds['monzo-api'][
+            'token'] else 'No access_token field'
     else:
         accounts[0]['token_info'] = 'No token found'
 
@@ -227,10 +230,9 @@ def mount_source_server(input, output, session):
                 f"Ping failed for 'monzo-api': {e}", type="error", duration=None
             )
 
-
     @reactive.effect
     @reactive.event(input[f"refresh_{sid}_token_button"])
-    def _on_test_click():
+    def _on_refresh_token_click():
         try:
             monzo_client.refresh_token()  # for example
             ui.notification_show(
@@ -305,6 +307,10 @@ def mount_source_server(input, output, session):
 
 
 app_ui = shiny_app.app_ui_factory(
+    ui.row(
+        ui.tags.a("Monzo auth", href=f"http://127.0.0.1:8003/auth/monzo"),
+        ui.tags.a("True Layer auth", href=f"http://127.0.0.1:8003/auth/truelayer"),
+    ),
     ui.navset_tab(
         ui.nav_panel('MonzoApi', source_ui())
     )

--- a/services/auth/truelayer_auth_app.py
+++ b/services/auth/truelayer_auth_app.py
@@ -175,7 +175,8 @@ def source_ui(source: str):
                                 choices={'last': 'Since last fetch', 'max': 'All available (90 days)'},
                                 selected='last',
                             ),
-                            ui.input_task_button(id=f"fetch_{sid}_button", label="Fetch data...", width='10%', height='10%'),
+                            ui.input_task_button(id=f"fetch_{sid}_button", label="Fetch data...", width='10%',
+                                                 height='10%'),
                         )
                     ),
                     ui.card_footer(
@@ -278,6 +279,10 @@ def mount_source_server(source: str, input, output, session):
 sources = ["ob-hsbc", "ob-revolut", "ob-monzo"]
 
 app_ui = shiny_app.app_ui_factory(
+    ui.row(
+        ui.tags.a("Monzo auth", href=f"http://127.0.0.1:8003/auth/monzo"),
+        ui.tags.a("True Layer auth", href=f"http://127.0.0.1:8003/auth/truelayer"),
+    ),
     ui.navset_tab(
         *(ui.nav_panel(src.upper(), source_ui(src)) for src in sources)
     )

--- a/tests/test_auth_callbacks.py
+++ b/tests/test_auth_callbacks.py
@@ -1,0 +1,38 @@
+import datetime as dt
+
+from services.auth.callbacks import _find_truelayer_session, _is_recent, CALLBACK_MAX_AGE_MINUTES
+
+
+def test_is_recent_accepts_fresh_timestamp():
+    now = dt.datetime.utcnow()
+    assert _is_recent(now.isoformat()) is True
+
+
+def test_is_recent_rejects_old_timestamp():
+    old = dt.datetime.utcnow() - dt.timedelta(minutes=CALLBACK_MAX_AGE_MINUTES + 1)
+    assert _is_recent(old.isoformat()) is False
+
+
+def test_find_truelayer_session_matches_by_state():
+    creds = {
+        "truelayer": {
+            "sources": {
+                "ob-hsbc": {
+                    "_transient_store": {
+                        "ob-hsbc": {"state": "abc", "created_at": dt.datetime.utcnow().isoformat()}
+                    }
+                },
+                "ob-monzo": {"_transient_store": {"other": {"state": "zzz"}}},
+            }
+        }
+    }
+
+    bank, provider_id, metadata = _find_truelayer_session(creds, "abc")
+    assert bank == "ob-hsbc"
+    assert provider_id == "ob-hsbc"
+    assert metadata["state"] == "abc"
+
+
+def test_find_truelayer_session_returns_none_for_unknown_state():
+    creds = {"truelayer": {"sources": {"ob-hsbc": {"_transient_store": {"ob-hsbc": {"state": "abc"}}}}}}
+    assert _find_truelayer_session(creds, "missing") is None


### PR DESCRIPTION
## Summary
- add a Starlette callback endpoint to process provider redirects with state/age validation and placeholder handling for Trading212
- record pending Monzo authorisation state when issuing login URLs so callbacks cannot overwrite credentials without a matching state
- add helper tests covering callback freshness checks and state lookups

## Testing
- python -m pytest tests/test_auth_callbacks.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693619e2d784832695fba3fa11540630)