### PR TITLE
Strip timezone info from statement transformers

### DIFF
--- a/mecon/etl/transformers.py
+++ b/mecon/etl/transformers.py
@@ -112,6 +112,7 @@ class MonzoStatementTransformer(DataframeTransformer):
         df_transformed = df_transformed.reindex(
             columns=['id', 'datetime', 'amount', 'currency', 'amount_cur', 'description'])
 
+        df_transformed['datetime'] = StatementTransformer._strip_timezone(df_transformed['datetime'])
         return df_transformed
 
 
@@ -145,11 +146,17 @@ class RevoStatementTransformer(DataframeTransformer):
         )
         df_transformed['description'] = 'bank:Revolut, ' + df_transformed['description']
 
+        df_transformed['datetime'] = StatementTransformer._strip_timezone(df_transformed['datetime'])
         return df_transformed
 
 
 class StatementTransformer(DataframeTransformer, abc.ABC):
     SOURCES = ['Monzo', 'MonzoAPI', 'HSBC', 'Revolut', 'INVENG', 'HSBCSVR', 'TRD212']
+
+    @staticmethod
+    def _strip_timezone(datetime_series: pd.Series) -> pd.Series:
+        # TODO: reintroduce proper timezone handling once all sources share the same convention
+        return pd.to_datetime(datetime_series).dt.tz_localize(None)
 
     def read_df(self, path):  # TODO moved to statement class
         df = pd.read_csv(path, index_col=None)
@@ -211,6 +218,7 @@ class HSBCFileStatementTransformer(StatementTransformer):
         df_transformed = df_transformed.rename(columns={'id': 'id', 'datetime': 'datetime', 'amount': 'amount',
                                                         'currency': 'currency', 'amount_cur': 'amount_cur',
                                                         'description': 'description'})
+        df_transformed['datetime'] = self._strip_timezone(df_transformed['datetime'])
         df_transformed.sort_values('datetime', inplace=True)
         return df_transformed
 
@@ -257,6 +265,7 @@ class MonzoFileStatementTransformer(StatementTransformer):
         df_transformed = df_transformed.reindex(
             columns=['id', 'datetime', 'amount', 'currency', 'amount_cur', 'description'])
 
+        df_transformed['datetime'] = self._strip_timezone(df_transformed['datetime'])
         return df_transformed
 
 
@@ -299,6 +308,7 @@ class MonzoAPIFileStatementTransformer(StatementTransformer):
         df_transformed = df_transformed.reindex(
             columns=['id', 'datetime', 'amount', 'currency', 'amount_cur', 'description'])
 
+        df_transformed['datetime'] = self._strip_timezone(df_transformed['datetime'])
         return df_transformed
 
 
@@ -336,6 +346,7 @@ class RevoFileStatementTransformer(StatementTransformer):
         )
         df_transformed['description'] = f'bank:{self.source_name}, ' + df_transformed['description']
 
+        df_transformed['datetime'] = self._strip_timezone(df_transformed['datetime'])
         return df_transformed
 
 
@@ -356,6 +367,7 @@ class InvestEngineStatementTransformer(StatementTransformer):
 
         df_final = df[['id', 'datetime', 'amount', 'currency', 'amount_cur', 'description']]
 
+        df_final['datetime'] = self._strip_timezone(df_final['datetime'])
         return df_final
 
 
@@ -398,6 +410,7 @@ class Trading212StatementTransformer(StatementTransformer):
 
         df_final = df_transformed[['id', 'datetime', 'amount', 'currency', 'amount_cur', 'description']]
 
+        df_final['datetime'] = self._strip_timezone(df_final['datetime'])
         return df_final
 
 if __name__ == '__main__':
@@ -443,6 +456,7 @@ class TrueLayerStatementTransformer(StatementTransformer):
 
         logging.info(
             f"Transformed True Layer raw transactions shape {df.shape} for {df_transformed['datetime'].min()} to {df_transformed['datetime'].max()}")
+        df_transformed['datetime'] = self._strip_timezone(df_transformed['datetime'])
         return df_transformed
 
 

--- a/tests/unit_tests/test_statement_transformer_timezones.py
+++ b/tests/unit_tests/test_statement_transformer_timezones.py
@@ -1,0 +1,37 @@
+import pandas as pd
+
+from mecon.etl.transformers import MonzoAPIFileStatementTransformer, TrueLayerStatementTransformer
+
+
+def test_monzoapi_transformer_strips_timezone():
+    df = pd.DataFrame(
+        {
+            "created": ["2025-01-01T12:30:00+00:00"],
+            "id": ["txn_1"],
+            "local_currency": ["GBP"],
+            "amount": [100],
+            "local_amount": [100],
+            "extra": ["value"],
+        }
+    )
+
+    transformed = MonzoAPIFileStatementTransformer().transform(df)
+
+    assert transformed["datetime"].apply(lambda dt: dt.tzinfo is None).all()
+
+
+def test_truelayer_transformer_strips_timezone():
+    df = pd.DataFrame(
+        {
+            "transaction_id": ["abc"],
+            "timestamp": ["2025-02-01T10:00:00Z"],
+            "amount": [10],
+            "currency": ["GBP"],
+            "description": ["test"],
+            "meta": ["info"],
+        }
+    )
+
+    transformed = TrueLayerStatementTransformer(source="TrueLayerHSBC").transform(df)
+
+    assert transformed["datetime"].apply(lambda dt: dt.tzinfo is None).all()


### PR DESCRIPTION
## Summary
- add a shared helper to strip timezone information from statement transformer outputs and apply it across transformers
- ensure all transaction datetime fields are normalized to timezone-naive values to avoid merge errors
- add tests covering MonzoAPI and TrueLayer transformers to confirm timezone removal

## Testing
- python -m pytest tests/unit_tests/test_statement_transformer_timezones.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f4b48071c8326a4c8656a0d37b724)